### PR TITLE
feat: Auto run steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Run Tests
 on:
   push:
     branches:
-    - dev
     - main
   pull_request:
 

--- a/examples/planingfsi/flat_plate/run_flat_plate_cases.py
+++ b/examples/planingfsi/flat_plate/run_flat_plate_cases.py
@@ -76,7 +76,7 @@ class PlaningPlateCase(Case):
         return dataclasses.asdict(self.results)
 
     @step(condition=lambda self: not (self.case_dir / "configDict").exists())
-    def _create_input_files(self) -> None:
+    def create_input_files(self) -> None:
         print("Creating input files")
         case_dir_base = FLAT_PLATE_ROOT / "flat_plate_base"
         shutil.copytree(case_dir_base, self.case_dir)
@@ -86,19 +86,14 @@ class PlaningPlateCase(Case):
             fp.write(f"AOA: {self.angle_of_attack}\n")
 
     @step(condition=lambda self: not (self.case_dir / "mesh").exists())
-    def _generate_mesh(self) -> None:
+    def generate_mesh(self) -> None:
         print("Generating mesh")
         subprocess.run(["planingfsi", "mesh"], cwd=str(self.case_dir))
 
     @step(condition=lambda self: not list(self.case_dir.glob("[0-9]*")))
-    def _run_planingfsi(self) -> None:
+    def run_planingfsi(self) -> None:
         print("Running planingfsi")
         subprocess.run(["planingfsi", "run"], cwd=str(self.case_dir))
-
-    def run(self) -> None:
-        self._create_input_files()
-        self._generate_mesh()
-        self._run_planingfsi()
 
 
 def plot_summary_results(cases: CaseList[PlaningPlateCase]) -> None:

--- a/src/lembas/core.py
+++ b/src/lembas/core.py
@@ -114,7 +114,7 @@ def step(condition: Callable[[Any], bool] | None = None) -> Any:
     def decorator(f: StepMethod) -> StepMethod:
         @functools.wraps(f)
         def new_f(self: Case) -> None:
-            if condition is not None and condition(self):
+            if condition is None or condition(self):
                 return f(self)
             else:
                 return None

--- a/src/lembas/core.py
+++ b/src/lembas/core.py
@@ -5,6 +5,7 @@ import types
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
+from functools import WRAPPER_ASSIGNMENTS
 from typing import Any
 from typing import ClassVar
 from typing import Generic
@@ -134,8 +135,11 @@ def step(condition: Callable[[Any], bool] | None = None) -> Any:
     """
 
     def decorator(f: StepMethod) -> StepMethod:
-        # TODO: Need to do equivalent of functools.wraps here
-        return CaseStep(f, condition=condition)
+        new_method = CaseStep(f, condition=condition)
+        # This is largely a replica of functools.wraps, which doesn't seem to work
+        for attr in WRAPPER_ASSIGNMENTS:
+            setattr(new_method, attr, getattr(f, attr))
+        return new_method
 
     return decorator
 

--- a/src/lembas/core.py
+++ b/src/lembas/core.py
@@ -116,8 +116,7 @@ def step(condition: Callable[[Any], bool] | None = None) -> Any:
         def new_f(self: Case) -> None:
             if condition is None or condition(self):
                 return f(self)
-            else:
-                return None
+            return None
 
         new_f.is_case_step = True  # type: ignore
 

--- a/src/lembas/core.py
+++ b/src/lembas/core.py
@@ -85,12 +85,12 @@ class InputParameter:
             return self._default
 
 
-StepMethod = Callable[["Case"], None]
+RawCaseStepMethod = Callable[["Case"], None]
 
 
 class CaseStep:
     def __init__(
-        self, func: StepMethod, *, condition: Callable[[Any], bool] | None = None
+        self, func: RawCaseStepMethod, *, condition: Callable[[Any], bool] | None = None
     ):
         self._func = func
         self._condition = condition
@@ -134,7 +134,7 @@ def step(condition: Callable[[Any], bool] | None = None) -> Any:
 
     """
 
-    def decorator(f: StepMethod) -> StepMethod:
+    def decorator(f: RawCaseStepMethod) -> CaseStep:
         new_method = CaseStep(f, condition=condition)
         # This is largely a replica of functools.wraps, which doesn't seem to work
         for attr in WRAPPER_ASSIGNMENTS:
@@ -147,7 +147,7 @@ def step(condition: Callable[[Any], bool] | None = None) -> Any:
 class Case:
     """Base case for all cases."""
 
-    _steps: ClassVar[list[StepMethod]]
+    _steps: ClassVar[list[CaseStep]]
 
     def __init_subclass__(cls, **kwargs: Any):
         cls._steps = [

--- a/src/lembas/core.py
+++ b/src/lembas/core.py
@@ -138,7 +138,7 @@ def step(condition: Callable[[Any], bool] | None = None) -> Any:
         new_method = CaseStep(f, condition=condition)
         # This is largely a replica of functools.wraps, which doesn't seem to work
         for attr in WRAPPER_ASSIGNMENTS:
-            setattr(new_method, attr, getattr(f, attr))
+            setattr(new_method, attr, getattr(f, attr, None))
         return new_method
 
     return decorator

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -17,7 +17,7 @@ class MyCase(Case):
     first_step_has_been_run = InputParameter(default=False)
     second_step_has_been_run = InputParameter(default=False)
 
-    @step(condition=lambda self: self.my_param > 4)
+    @step(condition=lambda self: self.my_param > 4, requires="second_step")
     def change_param_with_default(self) -> None:
         self.param_with_default = 5.0
 
@@ -88,7 +88,7 @@ def test_case_step_condition_is_met(case: MyCase) -> None:
 
 def test_case_steps_order(case: MyCase) -> None:
     step_names = [step.name for step in case.steps]  # type: ignore
-    assert step_names == ["change_param_with_default", "first_step", "second_step"]
+    assert step_names == ["first_step", "second_step", "change_param_with_default"]
 
 
 @pytest.fixture()

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -14,16 +14,23 @@ class MyCase(Case):
     my_param = InputParameter(type=float, min=2.0, max=5.0)
     param_with_default = InputParameter(default=10.0)
     required_param = InputParameter(type=float)
-    has_been_run = InputParameter(default=False)
+    first_step_has_been_run = InputParameter(default=False)
+    second_step_has_been_run = InputParameter(default=False)
 
     @step(condition=lambda self: self.my_param > 4)
     def change_param_with_default(self) -> None:
         self.param_with_default = 5.0
 
-    @step
-    def set_has_been_run(self) -> None:
+    @step(requires="first_step")
+    def second_step(self) -> None:
         """Set has_been_run to True."""
-        self.has_been_run = True
+        if not self.first_step_has_been_run:
+            raise RuntimeError
+        self.second_step_has_been_run = True
+
+    @step
+    def first_step(self) -> None:
+        self.first_step_has_been_run = True
 
 
 @pytest.fixture()
@@ -63,7 +70,7 @@ def test_case_parameter_bounds_raises_exception(
 
 def test_case_step_docstring(case: MyCase) -> None:
     """The docstring is replaced on a wrapped @step method."""
-    assert case.set_has_been_run.__doc__ == "Set has_been_run to True."
+    assert case.second_step.__doc__ == "Set has_been_run to True."
 
 
 def test_case_step_condition_is_not_met(case: MyCase) -> None:
@@ -77,6 +84,11 @@ def test_case_step_condition_is_met(case: MyCase) -> None:
     case.my_param = 5.0
     case.change_param_with_default()
     assert case.param_with_default == pytest.approx(5.0)
+
+
+def test_case_steps_order(case: MyCase) -> None:
+    step_names = [step.name for step in case.steps]  # type: ignore
+    assert step_names == ["change_param_with_default", "first_step", "second_step"]
 
 
 @pytest.fixture()
@@ -97,9 +109,9 @@ class TestCaseList:
 
     def test_run_all_cases(self, case_list: CaseList, case: MyCase) -> None:
         case_list.add(case)
-        assert not case.has_been_run
+        assert not case.second_step_has_been_run
         case_list.run_all()
-        assert case.has_been_run
+        assert case.second_step_has_been_run
 
     def test_build_from_iterable(self) -> None:
         case_list = CaseList(MyCase(required_param=i) for i in range(10))

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -20,7 +20,8 @@ class MyCase(Case):
     def change_param_with_default(self) -> None:
         self.param_with_default = 5.0
 
-    def run(self) -> None:
+    @step()
+    def set_has_been_run(self) -> None:
         self.has_been_run = True
 
 

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -20,7 +20,7 @@ class MyCase(Case):
     def change_param_with_default(self) -> None:
         self.param_with_default = 5.0
 
-    @step()
+    @step
     def set_has_been_run(self) -> None:
         """Set has_been_run to True."""
         self.has_been_run = True

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -22,6 +22,7 @@ class MyCase(Case):
 
     @step()
     def set_has_been_run(self) -> None:
+        """Set has_been_run to True."""
         self.has_been_run = True
 
 
@@ -58,6 +59,11 @@ def test_case_parameter_bounds_raises_exception(
     """An exception is raised when attempting to set the value out of bounds."""
     with pytest.raises(ValueError):
         case.my_param = input_value
+
+
+def test_case_step_docstring(case: MyCase) -> None:
+    """The docstring is replaced on a wrapped @step method."""
+    assert case.set_has_been_run.__doc__ == "Set has_been_run to True."
 
 
 def test_case_step_condition_is_not_met(case: MyCase) -> None:


### PR DESCRIPTION
Enable registration of case steps, and automatic processing via `case.run()`.

We can now define case handlers like the following, and the steps will be run in order based on the `requires` arguments:

```python
class MyCase(Case):
    my_param = InputParameter(type=float, min=2.0, max=5.0)
    param_with_default = InputParameter(default=10.0)
    required_param = InputParameter(type=float)
    first_step_has_been_run = InputParameter(default=False)
    second_step_has_been_run = InputParameter(default=False)

    @step(condition=lambda self: self.my_param > 4, requires="second_step")
    def change_param_with_default(self) -> None:
        self.param_with_default = 5.0

    @step(requires="first_step")
    def second_step(self) -> None:
        """Set has_been_run to True."""
        if not self.first_step_has_been_run:
            raise RuntimeError
        self.second_step_has_been_run = True

    @step
    def first_step(self) -> None:
        self.first_step_has_been_run = True
```