### PR TITLE
chore(ci): Use hyphenated version for 3.11 releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.9', '3.10']
         include:
-        - python-version: '3.11.0-beta.5'
+        - python-version: '3.11.0-beta - 3.11'
           os: ubuntu-latest
           experimental: true
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Widens range of versions to capture upcoming releases and pre-releases of Python 3.11