### PR TITLE
bugfix: API docs missing from readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.9"
   commands:
   - pip install -r docs/requirements.txt
-  - sphinx-apidoc -f -o docs/source/api src/lembas -H "API Docs" -T
+  - sphinx-apidoc -f -o docs/source/api src/lembas -H "API Docs" -M
   - sphinx-build -b html -d docs/build/doctrees docs/source _readthedocs/html
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.9"
   commands:
   - pip install -r docs/requirements.txt
-  - sphinx-apidoc -f -o docs/source/api src/lembas -H "API Docs" -T -M
+  - sphinx-apidoc -f -o docs/source/api src/lembas -H "API Docs" -T
   - sphinx-build -b html -d docs/build/doctrees docs/source _readthedocs/html
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Fixes bug when building docs for readthedocs.

We need to remove the `-T` flag from the `sphinx-apidoc` command because that was removing the TOC file.