### PR TITLE
chore: Move mypy config to pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install library
       run: pip install ".[ci]"
+    - name: Static type checking
+      run: mypy
     - name: Test with pytest
       run: |
         pytest \

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-python_version = 3.9
-disallow_untyped_defs = true
-ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ requires-python = ">=3.9"
 ci = ["lembas[dev]"]
 dev = [
   "pytest<=7.2",
-  "pytest-cov<=3.1"
+  "pytest-cov<=3.1",
+  "mypy"
 ]
 docs = [
   "myst-parser",
@@ -32,6 +33,15 @@ examples = [
 [tool.isort]
 force_single_line = true
 profile = "black"
+
+[tool.mypy]
+disallow_untyped_defs = true
+files = [
+  "src/**/*.py",
+  "tests/**/*.py"
+]
+ignore_missing_imports = true
+python_version = "3.9"
 
 [tool.setuptools_scm]
 write_to = "src/lembas/_version.py"


### PR DESCRIPTION
Move `mypy` config to `pyproject.toml` and add `mypy` to testing pipeline.