### PR TITLE
feat: Add ability to mark a parameter as a control parameter

### DIFF
--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -136,7 +136,7 @@ class Case:
         attr_names = (
             k
             for k, v in self.__class__.__dict__.items()
-            if isinstance(v, InputParameter)
+            if isinstance(v, InputParameter) and v.include_in_inputs_dict
         )
         return {n: getattr(self, n) for n in attr_names}
 

--- a/src/lembas/param.py
+++ b/src/lembas/param.py
@@ -1,6 +1,7 @@
 """Custom parameter types that can be defined on `lembas.Case` instances."""
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -27,6 +28,8 @@ class InputParameter:
         default: The default value. If the type is not set, the type of the default will be used.
         min: The minimum value for the parameter (if it is a float).
         max: The maximum value for the parameter (if it is a float).
+        control: Set as True to indicate a runtime control parameter.
+            These parameters will be excluded from the `case.inputs` dictionary.
 
     """
 
@@ -34,6 +37,7 @@ class InputParameter:
     _type: type | None
     _min_value: float | None
     _max_value: float | None
+    _control: bool
 
     def __init__(
         self,
@@ -42,6 +46,7 @@ class InputParameter:
         default: Any = _NoDefault,
         min: float | None = None,
         max: float | None = None,
+        control: bool = False,
     ):
         if type is not None:
             self._type = type
@@ -55,6 +60,7 @@ class InputParameter:
         self._default = default
         self._min_value = min
         self._max_value = max
+        self._control = control
 
     def __set_name__(self, owner: type[Case], name: str) -> None:
         self._name = name
@@ -93,3 +99,8 @@ class InputParameter:
                     "has no default value and must be specified explicitly"
                 )
             return self._default
+
+    @cached_property
+    def include_in_inputs_dict(self) -> bool:
+        """If True, include the parameter in the `case.inputs` dictionary."""
+        return not self._control

--- a/src/lembas/param.py
+++ b/src/lembas/param.py
@@ -34,10 +34,6 @@ class InputParameter:
     """
 
     _name: str
-    _type: type | None
-    _min_value: float | None
-    _max_value: float | None
-    _control: bool
 
     def __init__(
         self,

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -18,6 +18,7 @@ class MyCase(Case):
     required_param = InputParameter(type=float)
     first_step_has_been_run = InputParameter(default=False)
     second_step_has_been_run = InputParameter(default=False)
+    control_param = InputParameter(default=1.0, control=True)
 
     @step(condition=lambda self: self.my_param > 4, requires="second_step")
     def change_param_with_default(self) -> None:


### PR DESCRIPTION
This allows us to ignore it from the `case.inputs` dictionary and this the `lembas-case.toml` file.