### PR TITLE
feat: Allow a string to be specified as the step condition

### DIFF
--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -16,12 +16,13 @@ class MyCase(Case):
     my_param = InputParameter(type=float, min=2.0, max=5.0)
     param_with_default = InputParameter(default=10.0)
     required_param = InputParameter(type=float)
-    first_step_has_been_run = InputParameter(default=False)
-    second_step_has_been_run = InputParameter(default=False)
     control_param = InputParameter(default=1.0, control=True)
     control_param_true = InputParameter(default=True, control=True)
     control_param_false = InputParameter(default=False, control=True)
 
+    # Attributes used to check whether steps have been run
+    first_step_has_been_run = False
+    second_step_has_been_run = False
     step_has_been_triggered_by_string = False
     step_has_been_triggered_by_string_not = False
 
@@ -134,11 +135,9 @@ def test_casehandler_full_name(case: MyCase) -> None:
 def test_case_inputs_dict(case: MyCase) -> None:
     case.required_param = 4.0
     assert case.inputs == {
-        "first_step_has_been_run": False,
         "my_param": 3.0,
         "param_with_default": 10.0,
         "required_param": 4.0,
-        "second_step_has_been_run": False,
     }
 
 

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -119,6 +119,24 @@ def test_case_step_string_condition_not(case: MyCase) -> None:
     assert case.step_has_been_triggered_by_string_not
 
 
+@pytest.mark.parametrize(
+    "condition",
+    [
+        pytest.param("is some_attribute", id="only-not-allowed"),
+        pytest.param("is not some_attribute", id="max-two-words"),
+        pytest.param("", id="at-least-one-word"),
+    ],
+)
+def test_string_condition_invalid_raises_exception(condition: str) -> None:
+    """The string must be either an attribute name, or `not attribute_name`."""
+    with pytest.raises(ValueError):
+
+        class MyClass(Case):
+            @step(condition=condition)
+            def anything(self) -> None:
+                ...
+
+
 def test_case_steps_order(case: MyCase) -> None:
     expected_steps = ["first_step", "second_step", "change_param_with_default"]
     # Extract the step names if they are expected (drop ones without a requires)

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -134,7 +134,7 @@ def test_string_condition_invalid_raises_exception(condition: str) -> None:
         class MyClass(Case):
             @step(condition=condition)
             def anything(self) -> None:
-                ...
+                ...  # pragma: no cover
 
 
 def test_case_steps_order(case: MyCase) -> None:


### PR DESCRIPTION
This does an attribute lookup on the case instance and is useful for simple boolean checks.

Example usage:

```python
class MyCase(Case):
    run = InputParameter(default=True, control=True)
    skip = InputParameter(default=False, control=True)

    @step(condition="run")
    def if_run_true(self) -> None:
        print("Step has been run!")

    @step(condition="not skip")
    def if_skip_false(self) -> None:
        print("Step has not been skipped!")
```