### PR TITLE
feat: Results class

### DIFF
--- a/examples/planingfsi/filled_dam/run_filled_dam_cases.py
+++ b/examples/planingfsi/filled_dam/run_filled_dam_cases.py
@@ -9,6 +9,7 @@ import dataclasses
 from functools import cached_property
 from pathlib import Path
 from typing import Any
+from typing import NamedTuple
 
 import numpy as np
 import pandas
@@ -21,6 +22,7 @@ from planingfsi import Simulation
 from lembas import Case
 from lembas import CaseList
 from lembas import InputParameter
+from lembas import result
 from lembas import step
 
 BASE_DIR = Path(__file__).parent
@@ -32,8 +34,7 @@ class Coordinate:
     y: float
 
 
-@dataclasses.dataclass
-class HydrostaticDamResults:
+class HydrostaticDamResults(NamedTuple):
     max_height: float
     coords: list[Coordinate]
 
@@ -45,8 +46,8 @@ class HydrostaticDamCase(Case):
     def case_dir(self) -> Path:
         return BASE_DIR / "cases" / f"href={self.reference_head:0.3f}m"
 
-    @cached_property
-    def results(self) -> HydrostaticDamResults:
+    @result("max_height", "coords")
+    def load_results(self) -> HydrostaticDamResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
         results_dirs = sorted(
@@ -71,7 +72,7 @@ class HydrostaticDamCase(Case):
     @cached_property
     def results_dict(self) -> dict[str, Any]:
         """A combined dictionary of results & inputs."""
-        return dataclasses.asdict(self.results)
+        return {k: self.results.get(k) for k in ["max_height", "coords"]}
 
     @staticmethod
     def generate_mesh() -> Mesh:

--- a/examples/planingfsi/flat_plate/run_flat_plate_cases.py
+++ b/examples/planingfsi/flat_plate/run_flat_plate_cases.py
@@ -6,12 +6,12 @@ Each case is run with `planingfsi` and is characterized by the Froude number
 """
 from __future__ import annotations
 
-import dataclasses
 import shutil
 import subprocess
 from functools import cached_property
 from pathlib import Path
 from typing import Any
+from typing import NamedTuple
 
 import numpy
 import pandas
@@ -21,13 +21,13 @@ from planingfsi.dictionary import load_dict_from_file
 from lembas import Case
 from lembas import CaseList
 from lembas import InputParameter
+from lembas import result
 from lembas import step
 
 FLAT_PLATE_ROOT = Path(__file__).parent
 
 
-@dataclasses.dataclass
-class PlaningPlateResults:
+class PlaningPlateResults(NamedTuple):
     drag: float
     lift: float
     moment: float
@@ -46,8 +46,8 @@ class PlaningPlateCase(Case):
             f"Fr={self.froude_num:0.2f}_AOA={self.angle_of_attack:0.2f}",
         )
 
-    @cached_property
-    def results(self) -> PlaningPlateResults:
+    @result("drag", "lift", "moment")
+    def load_results(self) -> PlaningPlateResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
         results_dirs = sorted(
@@ -73,7 +73,7 @@ class PlaningPlateCase(Case):
     @cached_property
     def results_dict(self) -> dict[str, Any]:
         """A combined dictionary of results & inputs."""
-        return dataclasses.asdict(self.results)
+        return {k: self.results.get(k) for k in ["drag", "lift", "moment"]}
 
     @step(condition=lambda self: not (self.case_dir / "configDict").exists())
     def create_input_files(self) -> None:

--- a/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/filled_dam.py
+++ b/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/filled_dam.py
@@ -19,9 +19,10 @@ from planingfsi import FlexibleMembraneSubstructure
 from planingfsi import Mesh
 from planingfsi import Simulation
 
-from lembas import Case, result
+from lembas import Case
 from lembas import CaseList
 from lembas import InputParameter
+from lembas import result
 from lembas import step
 
 BASE_DIR = Path(__file__).parent

--- a/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/flat_plate.py
+++ b/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/flat_plate.py
@@ -15,8 +15,9 @@ from typing import NamedTuple
 
 from planingfsi.dictionary import load_dict_from_file
 
-from lembas import Case, result
+from lembas import Case
 from lembas import InputParameter
+from lembas import result
 from lembas import step
 
 

--- a/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/flat_plate.py
+++ b/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/flat_plate.py
@@ -6,22 +6,21 @@ Each case is run with `planingfsi` and is characterized by the Froude number
 """
 from __future__ import annotations
 
-import dataclasses
 import shutil
 import subprocess
 from functools import cached_property
 from pathlib import Path
 from typing import Any
+from typing import NamedTuple
 
 from planingfsi.dictionary import load_dict_from_file
 
-from lembas import Case
+from lembas import Case, result
 from lembas import InputParameter
 from lembas import step
 
 
-@dataclasses.dataclass
-class PlaningPlateResults:
+class PlaningPlateResults(NamedTuple):
     drag: float
     lift: float
     moment: float
@@ -40,8 +39,8 @@ class PlaningPlateCase(Case):
             f"Fr={self.froude_num:0.2f}_AOA={self.angle_of_attack:0.2f}",
         )
 
-    @cached_property
-    def results(self) -> PlaningPlateResults:
+    @result("drag", "lift", "moment")
+    def load_results(self) -> PlaningPlateResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
         results_dirs = sorted(
@@ -67,7 +66,7 @@ class PlaningPlateCase(Case):
     @cached_property
     def results_dict(self) -> dict[str, Any]:
         """A combined dictionary of results & inputs."""
-        return dataclasses.asdict(self.results)
+        return {k: self.results.get(k) for k in ["drag", "lift", "moment"]}
 
     @step(condition=lambda self: not (self.case_dir / "configDict").exists())
     def create_input_files(self) -> None:

--- a/src/lembas/__init__.py
+++ b/src/lembas/__init__.py
@@ -3,5 +3,6 @@ from lembas.case import Case
 from lembas.case import CaseList
 from lembas.case import step
 from lembas.param import InputParameter
+from lembas.results import result
 
-__all__ = ["Case", "CaseList", "InputParameter", "step", "__version__"]
+__all__ = ["Case", "CaseList", "InputParameter", "result", "step", "__version__"]

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -23,7 +23,7 @@ from lembas.param import InputParameter
 
 __all__ = ["Case", "CaseList", "step"]
 
-LEMBAS_CASE_TOML_FILENAME = "lembas-case.toml"
+LEMBAS_CASE_TOML_FILENAME = Path("lembas", "case.toml")
 
 TCase = TypeVar("TCase", bound="Case")
 RawCaseStepMethod = Callable[[TCase], None]

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -20,10 +20,10 @@ import toml
 
 from lembas.logging import logger
 from lembas.param import InputParameter
+from lembas.results import Results
 
 __all__ = ["Case", "CaseList", "step"]
 
-from lembas.results import Results
 
 LEMBAS_CASE_TOML_FILENAME = Path("lembas", "case.toml")
 

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -98,6 +98,7 @@ class Case:
     """
 
     _steps: ClassVar[dict[str, CaseStep]]
+    results: Results
 
     def __init_subclass__(cls, **kwargs: Any):
         cls._steps = {

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -23,6 +23,8 @@ from lembas.param import InputParameter
 
 __all__ = ["Case", "CaseList", "step"]
 
+from lembas.results import Results
+
 LEMBAS_CASE_TOML_FILENAME = Path("lembas", "case.toml")
 
 TCase = TypeVar("TCase", bound="Case")
@@ -108,6 +110,7 @@ class Case:
         self._completed_steps: set[str] = set()
         for name, value in kwargs.items():
             setattr(self, name, value)
+        self.results = Results(parent=self)
 
     def __str__(self) -> str:
         cls = self.__class__

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lembas.case import Case
+
+
+class Results:
+    """A generic container for results of a case.
+
+    Implements lazy loading of results, where the result accessors are specified by @result
+    decorator.
+
+    """
+
+    def __init__(self, parent: Case):
+        self._parent = parent
+
+    @property
+    def parent(self) -> Case:
+        # TODO: Replace with a weakref to remove memory leak
+        return self._parent

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -76,6 +76,10 @@ class Results:
         except KeyError:
             raise AttributeError(f"Result '{item}' is not defined")
 
+    def get(self, item: str, default: Any = None) -> Any:
+        """Dictionary-like get access."""
+        return getattr(self, item, default)
+
 
 def result(
     *func_or_names: Callable[[TCase], Any] | str

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import weakref
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -15,9 +17,13 @@ class Results:
     """
 
     def __init__(self, parent: Case):
-        self._parent = parent
+        self._parent = weakref.ref(parent)
 
-    @property
+    @cached_property
     def parent(self) -> Case:
-        # TODO: Replace with a weakref to remove memory leak
-        return self._parent
+        parent = self._parent()
+        if parent is None:
+            raise ValueError(
+                "The parent has been de-referenced. This shouldn't happen."
+            )
+        return parent

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import weakref
 from functools import cached_property
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import TypeVar
 
 if TYPE_CHECKING:
     from lembas.case import Case
+
+
+TCase = TypeVar("TCase", bound="Case")
+RawCaseMethod = Callable[[TCase], Any]
 
 
 class Results:
@@ -28,3 +35,82 @@ class Results:
                 "The parent has been de-referenced. This shouldn't happen."
             )
         return parent
+
+    def __getattr__(self, item: str) -> Any:
+        if item in self.__dict__:
+            return self.__dict__[item]
+
+        # During attribute access, we search the class for methods to which have been
+        # attached a "_provides_results" tuple. If we find that, and the requested
+        # result is in that tuple, we call the method (once) and cache the results in
+        # the self.__dict__ for later, faster retrieval.
+        cls = self.parent.__class__
+        for method_name, method_func in cls.__dict__.items():
+            try:
+                provides_results = getattr(method_func, "_provides_results")
+            except AttributeError:
+                continue  # to next method
+
+            provides_results = provides_results or tuple()
+            if item not in provides_results:
+                continue
+
+            results = method_func(self.parent)
+            if not isinstance(results, tuple):
+                results = (results,)
+
+            num_expected_results = len(provides_results)
+            num_results = len(results)
+            if num_expected_results != num_results:
+                raise ValueError(
+                    f"Results method {method_name} returns {num_results} items, "
+                    f"only {num_expected_results} results are declared in the @result "
+                    "decorator."
+                )
+
+            for n, r in zip(provides_results, results):
+                setattr(self, n, r)
+
+        try:
+            return self.__dict__[item]
+        except KeyError:
+            raise AttributeError(f"Result '{item}' is not defined")
+
+
+def result(
+    *func_or_names: Callable[[TCase], Any] | str
+) -> RawCaseMethod | Callable[[RawCaseMethod], RawCaseMethod]:
+    """A decorator to annotate a method that provides result(s).
+
+    The decorator accepts a variadic list of names for the provided result(s). The method
+    can return a single object or a tuple of objects, which must map to the number of names
+    provided. The results are then available from within other case handler methods like
+    self.results.result_name.
+
+    """
+
+    if any(callable(fn) for fn in func_or_names):
+        # This case captures the non-argument form, i.e. @result
+        # In this case, there should only be one argument, which is
+        # the decorated method.
+        try:
+            (method,) = func_or_names
+        except ValueError:
+            raise ValueError("Must only provide a single callable")
+        names = (method.__name__,)  # type: ignore
+        method._provides_results = names  # type: ignore
+        return method  # type: ignore
+
+    # We now handle the case with arguments, i.e. @result("name1", "name2")
+    names = func_or_names  # type: ignore
+
+    def decorator(m: RawCaseMethod) -> RawCaseMethod:
+        # Here, we attach the tuple of names to the method function object. We have to do
+        # this because we do not have access to the class object at the time when the
+        # decorator is called. The actual discovery of the name mapping is performed
+        # during attribute access on the case.results object, which does a search across
+        # the methods attached to the class at runtime.
+        m._provides_results = names  # type: ignore
+        return m
+
+    return decorator

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -37,9 +37,6 @@ class Results:
         return parent
 
     def __getattr__(self, item: str) -> Any:
-        if item in self.__dict__:
-            return self.__dict__[item]
-
         # During attribute access, we search the class for methods to which have been
         # attached a "_provides_results" tuple. If we find that, and the requested
         # result is in that tuple, we call the method (once) and cache the results in

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -30,7 +30,7 @@ class Results:
     def parent(self) -> Case:
         """A reference to the parent case with which these results are associated."""
         parent = self._parent()
-        if parent is None:
+        if parent is None:  # pragma: no cover
             raise ValueError(
                 "The parent has been de-referenced. This shouldn't happen."
             )
@@ -96,7 +96,7 @@ def result(
         # the decorated method.
         try:
             (method,) = func_or_names
-        except ValueError:
+        except ValueError:  # pragma: no cover
             raise ValueError("Must only provide a single callable")
         names = (method.__name__,)  # type: ignore
         method._provides_results = names  # type: ignore

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -21,6 +21,7 @@ class Results:
 
     @cached_property
     def parent(self) -> Case:
+        """A reference to the parent case with which these results are associated."""
         parent = self._parent()
         if parent is None:
             raise ValueError(

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -164,8 +164,8 @@ def test_case_lembas_toml(case: MyCase, tmp_path: Path) -> None:
     case.required_param = 4.0
     assert case.case_dir == tmp_path
     case._write_lembas_file()
-    assert (tmp_path / "lembas-case.toml").exists()
-    with (tmp_path / "lembas-case.toml").open("r") as fp:
+    assert (tmp_path / "lembas" / "case.toml").exists()
+    with (tmp_path / "lembas" / "case.toml").open("r") as fp:
         data = toml.load(fp)
     assert data == {
         "lembas": {"inputs": case.inputs, "case-handler": case.fully_resolved_name}

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,10 +1,25 @@
 import pytest
 
 from lembas import Case
+from lembas.results import result
 
 
 class MyCase(Case):
-    ...
+    @result
+    def some_result(self) -> str:
+        return "some_result_value"
+
+    @result("single_result")
+    def single_result_name_ignored(self) -> str:
+        return "single_result_value"
+
+    @result("first_result", "second_result")
+    def multiple_result_name_ignored(self) -> tuple[str, str]:
+        return "first_result_value", "second_result_value"
+
+    @result("first_result_expected", "second_result_expected")
+    def incorrect_number_of_results(self) -> str:
+        return "this_should_raise_an_error"
 
 
 @pytest.fixture()
@@ -14,3 +29,30 @@ def case() -> MyCase:
 
 def test_case_results_parent(case: MyCase) -> None:
     assert case.results.parent is case
+
+
+def test_case_results_get_attr_no_args(case: MyCase) -> None:
+    assert case.results.some_result == "some_result_value"
+
+
+def test_cas_results_get_attr_with_args_single(case: MyCase) -> None:
+    assert case.results.single_result == "single_result_value"
+
+
+def test_case_results_get_attr_multiple(case: MyCase) -> None:
+    assert case.results.first_result == "first_result_value"
+    assert case.results.second_result == "second_result_value"
+
+
+def test_case_results_incorrect_number_of_results(case: MyCase) -> None:
+    with pytest.raises(ValueError):
+        _ = case.results.first_result_expected
+
+
+def test_case_results_undefined(case: MyCase) -> None:
+    with pytest.raises(AttributeError):
+        _ = case.results.nonexistent_result
+
+
+def test_case_results_method_provides_results(case: MyCase) -> None:
+    assert MyCase.some_result._provides_results == ("some_result",)  # type: ignore

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -41,7 +41,7 @@ def test_cas_results_get_attr_with_args_single(case: MyCase) -> None:
 
 def test_case_results_get_attr_multiple(case: MyCase) -> None:
     assert case.results.first_result == "first_result_value"
-    assert case.results.second_result == "second_result_value"
+    assert case.results.get("second_result") == "second_result_value"
 
 
 def test_case_results_incorrect_number_of_results(case: MyCase) -> None:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,16 @@
+import pytest
+
+from lembas import Case
+
+
+class MyCase(Case):
+    ...
+
+
+@pytest.fixture()
+def case() -> MyCase:
+    return MyCase()
+
+
+def test_case_results_parent(case: MyCase) -> None:
+    assert case.results.parent is case

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,7 +1,7 @@
 import pytest
 
 from lembas import Case
-from lembas.results import result
+from lembas import result
 
 
 class MyCase(Case):


### PR DESCRIPTION
Adds a new `Results` class which is accessible for each `Case` via the `.results` attribute.

The class allows a user to define a result method, which is similar to a normal python `@property` decorator. The results methods can provide one or more values, which are cached for later access.

Example:
```python
class MyCase(Case):
    @result
    def some_result(self):
        return "some_result_value"

    @result("first_result", "second_result")
    def name_doesnt_matter(self):
        return "first_value", "second_value"

case = MyCase()
assert case.result.some_result == "some_result_value"
assert case.result.first_result == "first_value"
assert case.result.second_result == "second_value"
```