### PR TITLE
chore: migrate from black/isort/flake8 to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 120
-ignore = E203, W503
-exclude = venv
-per-file-ignores =
-    src/lead/core/__init__.py:E402,F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,16 @@ repos:
     exclude: "conda.recipe/.*"
   - id: check-toml
   - id: check-docstring-first
+  - id: check-added-large-files
+  - id: check-merge-conflict
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.0
+  hooks:
+  - id: ruff-check
+    args: [--fix]
+  - id: ruff-format
+
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.16.0
   hooks:
@@ -19,35 +29,19 @@ repos:
     exclude: "conda.recipe/.*"
   - id: pretty-format-toml
     args: [--autofix]
-- repo: https://github.com/sondrelg/pep585-upgrade
-  rev: "v1.0.1"
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
   hooks:
-  - id: upgrade-type-hints
-    args: ["--futures=true"]
-- repo: https://github.com/MarcoGorelli/absolufy-imports
-  rev: v0.3.1
-  hooks:
-  - id: absolufy-imports
-    exclude: "examples/plugins/.*"
-- repo: https://github.com/pycqa/isort
-  rev: 7.0.0
-  hooks:
-  - id: isort
-    name: isort
-    exclude: "examples/plugins/.*"
-- repo: https://github.com/psf/black
-  rev: 26.1.0
-  hooks:
-  - id: black
-- repo: https://github.com/pycqa/flake8
-  rev: 7.3.0
-  hooks:
-  - id: flake8
+  - id: codespell
+    args: [--write]
+
 - repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.47.0
   hooks:
   - id: markdownlint-fix
     args: [--ignore, README.md, --disable, MD041]
+
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.19.1
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Create a new virtual environment, activate it, and install in development mode:
 ```shell
 python -m venv venv
 . venv/bin/activate
-pip intall -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ## Run the tests

--- a/examples/planingfsi/filled_dam/run_filled_dam_cases.py
+++ b/examples/planingfsi/filled_dam/run_filled_dam_cases.py
@@ -51,9 +51,7 @@ class HydrostaticDamCase(Case):
     def load_results(self) -> HydrostaticDamResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
-        results_dirs = sorted(
-            self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
-        )
+        results_dirs = sorted(self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True)
         results_dir = results_dirs[0]
         coords = np.loadtxt(results_dir / "coords_dam.txt")
         return HydrostaticDamResults(
@@ -115,14 +113,14 @@ class HydrostaticDamCase(Case):
 
 def plot_summary_results(cases: CaseList[HydrostaticDamCase]) -> None:
     fig, ax = plt.subplots(1, 2, figsize=(10, 4))
-    df = pandas.DataFrame.from_records(
-        case.inputs_dict | case.results_dict for case in cases
-    ).drop(columns="coords")
+    df = pandas.DataFrame.from_records(case.inputs_dict | case.results_dict for case in cases).drop(
+        columns="coords"
+    )
     df.plot(x="reference_head", y="max_height", ax=ax[0], label="Max Dam Height [m]")
     ax[0].set_xlabel("Reference Head [m]")
 
     lines, colors = [], []
-    for i, case in enumerate(cases):
+    for _i, case in enumerate(cases):
         coords_df = pandas.DataFrame.from_records(case.results_dict["coords"])
         lines.append(coords_df[["x", "y"]].to_numpy())
         colors.append(case.reference_head)
@@ -139,9 +137,7 @@ def plot_summary_results(cases: CaseList[HydrostaticDamCase]) -> None:
 
 def main() -> None:
     cases: CaseList[HydrostaticDamCase] = CaseList()
-    cases.add_cases_by_parameter_sweep(
-        HydrostaticDamCase, reference_head=np.arange(0.8, 10.1, 0.2)
-    )
+    cases.add_cases_by_parameter_sweep(HydrostaticDamCase, reference_head=np.arange(0.8, 10.1, 0.2))
     cases.run_all()
 
     plot_summary_results(cases)

--- a/examples/planingfsi/flat_plate/run_flat_plate_cases.py
+++ b/examples/planingfsi/flat_plate/run_flat_plate_cases.py
@@ -51,9 +51,7 @@ class PlaningPlateCase(Case):
     def load_results(self) -> PlaningPlateResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
-        results_dirs = sorted(
-            self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
-        )
+        results_dirs = sorted(self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True)
         results_dir = results_dirs[0]
         results_dict = load_dict_from_file(results_dir / "forces_total.txt")
         return PlaningPlateResults(
@@ -99,9 +97,7 @@ class PlaningPlateCase(Case):
 
 def plot_summary_results(cases: CaseList[PlaningPlateCase]) -> None:
     """Create a plot of the lift from all the cases that were run."""
-    df = pandas.DataFrame.from_records(
-        case.results_dict | case.inputs_dict for case in cases
-    )
+    df = pandas.DataFrame.from_records(case.results_dict | case.inputs_dict for case in cases)
     df.plot.scatter(x="froude_num", y="lift", c="angle_of_attack", cmap="inferno")
     pyplot.show()
 

--- a/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/filled_dam.py
+++ b/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/filled_dam.py
@@ -51,9 +51,7 @@ class HydrostaticDamCase(Case):
     def load_results(self) -> HydrostaticDamResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
-        results_dirs = sorted(
-            self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
-        )
+        results_dirs = sorted(self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True)
         results_dir = results_dirs[0]
         coords = np.loadtxt(results_dir / "coords_dam.txt")
         return HydrostaticDamResults(
@@ -115,14 +113,14 @@ class HydrostaticDamCase(Case):
 
 def plot_summary_results(cases: CaseList[HydrostaticDamCase]) -> None:
     fig, ax = plt.subplots(1, 2, figsize=(10, 4))
-    df = pandas.DataFrame.from_records(
-        case.inputs_dict | case.results_dict for case in cases
-    ).drop(columns="coords")
+    df = pandas.DataFrame.from_records(case.inputs_dict | case.results_dict for case in cases).drop(
+        columns="coords"
+    )
     df.plot(x="reference_head", y="max_height", ax=ax[0], label="Max Dam Height [m]")
     ax[0].set_xlabel("Reference Head [m]")
 
     lines, colors = [], []
-    for i, case in enumerate(cases):
+    for _i, case in enumerate(cases):
         coords_df = pandas.DataFrame.from_records(case.results_dict["coords"])
         lines.append(coords_df[["x", "y"]].to_numpy())
         colors.append(case.reference_head)
@@ -139,9 +137,7 @@ def plot_summary_results(cases: CaseList[HydrostaticDamCase]) -> None:
 
 def main() -> None:
     cases: CaseList[HydrostaticDamCase] = CaseList()
-    cases.add_cases_by_parameter_sweep(
-        HydrostaticDamCase, reference_head=np.arange(0.8, 10.1, 0.2)
-    )
+    cases.add_cases_by_parameter_sweep(HydrostaticDamCase, reference_head=np.arange(0.8, 10.1, 0.2))
     cases.run_all()
 
     plot_summary_results(cases)

--- a/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/flat_plate.py
+++ b/examples/plugins/lembas-planingfsi/src/lembas_planingfsi/flat_plate.py
@@ -45,9 +45,7 @@ class PlaningPlateCase(Case):
     def load_results(self) -> PlaningPlateResults:
         """Load results from files and return."""
         # Find the latest time directory to load results from
-        results_dirs = sorted(
-            self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
-        )
+        results_dirs = sorted(self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True)
         results_dir = results_dirs[0]
         results_dict = load_dict_from_file(results_dir / "forces_total.txt")
         return PlaningPlateResults(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,6 @@ exclude_lines = [
   'if __name__ == "__main__":'
 ]
 
-[tool.isort]
-force_single_line = true
-profile = "black"
-
 [tool.mypy]
 disallow_untyped_defs = true
 files = [
@@ -60,6 +56,27 @@ files = [
 ]
 ignore_missing_imports = true
 python_version = "3.10"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+ignore = [
+  "E501"  # line too long (handled by formatter)
+]
+select = [
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
+  "UP",  # pyupgrade
+  "B",  # flake8-bugbear
+  "SIM"  # flake8-simplify
+]
+
+[tool.ruff.lint.isort]
+force-single-line = true
 
 [tool.setuptools_scm]
 write_to = "src/lembas/_version.py"

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 from typing import ClassVar
 from typing import Generic
-from typing import Optional
 from typing import TypeVar
 
 import toml
@@ -41,9 +40,7 @@ class CaseStep:
     ):
         self._func = func
         self._condition = self._validate_condition(condition)
-        self.requires = (
-            [requires] if isinstance(requires, str) else list(requires or [])
-        )
+        self.requires = [requires] if isinstance(requires, str) else list(requires or [])
 
     @cached_property
     def name(self) -> str:
@@ -64,9 +61,7 @@ class CaseStep:
             elif len(parts) == 2:
                 # The only two-part form allowed is "not attribute_name"
                 if parts[0].strip().lower() != "not":
-                    raise ValueError(
-                        "Can only use 'not' as modifier for string-based condition"
-                    )
+                    raise ValueError("Can only use 'not' as modifier for string-based condition")
                 return lambda case: not getattr(case, parts[1].strip())
             else:
                 raise ValueError(
@@ -102,9 +97,7 @@ class Case:
 
     def __init_subclass__(cls, **kwargs: Any):
         cls._steps = {
-            name: method
-            for name, method in cls.__dict__.items()
-            if isinstance(method, CaseStep)
+            name: method for name, method in cls.__dict__.items() if isinstance(method, CaseStep)
         }
 
     def __init__(self, **kwargs: Any):
@@ -135,16 +128,16 @@ class Case:
         return mod_prefix + cls.__qualname__
 
     @cached_property
-    def case_dir(self) -> Optional[Path]:
-        f"""An optional property that can be set for a subclass.
+    def case_dir(self) -> Path | None:
+        """An optional property that can be set for a subclass.
 
-        If set, the `{LEMBAS_CASE_TOML_FILENAME}` file will be written in this directory.
+        If set, the lembas case.toml file will be written in this directory.
 
         """
         return None
 
     @cached_property
-    def relative_case_dir(self) -> Optional[Path]:
+    def relative_case_dir(self) -> Path | None:
         """Return a case directory relative to current working directory if possible.
 
         If the case directory is not a subdirectory of current working directory, the absolute
@@ -189,9 +182,7 @@ class Case:
         case_summary_file.parent.mkdir(parents=True, exist_ok=True)
 
         self.log("Writing case summary to: %s", case_summary_file)
-        contents = {
-            "lembas": {"inputs": self.inputs, "case-handler": self.fully_resolved_name}
-        }
+        contents = {"lembas": {"inputs": self.inputs, "case-handler": self.fully_resolved_name}}
         with case_summary_file.open("w") as fp:
             toml.dump(contents, fp)
 
@@ -232,9 +223,7 @@ class CaseList(Generic[TCase]):
         self._cases.append(case)
         return case
 
-    def add_cases_by_parameter_sweep(
-        self, case_class: type[TCase], **kwargs: Any
-    ) -> None:
+    def add_cases_by_parameter_sweep(self, case_class: type[TCase], **kwargs: Any) -> None:
         """Add a number of cases by performing a parameter sweep using the Cartesian product.
 
         Args:
@@ -249,7 +238,7 @@ class CaseList(Generic[TCase]):
                 kwargs[key] = [value]
 
         for values in itertools.product(*kwargs.values()):
-            new_kwargs = {k: v for k, v in zip(kwargs.keys(), values)}
+            new_kwargs = dict(zip(kwargs.keys(), values, strict=True))
             case = case_class(**new_kwargs)
             self.add(case)
 
@@ -265,8 +254,7 @@ class CaseList(Generic[TCase]):
         return len(self._cases)
 
     def __iter__(self) -> Iterator[TCase]:
-        for case in self._cases:
-            yield case
+        yield from self._cases
 
 
 def step(

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -40,9 +39,7 @@ class Abort(typer.Abort):
 
 @app.callback(invoke_without_command=True, no_args_is_help=True)
 def main(
-    version: Optional[bool] = typer.Option(
-        None, "--version", help="Show project version and exit."
-    )
+    version: bool | None = typer.Option(None, "--version", help="Show project version and exit."),
 ) -> None:
     """Command Line Interface for Lembas."""
     if version:
@@ -53,9 +50,9 @@ def main(
 @app.command()
 def run(
     case_handler_name: str,
-    params: Optional[list[str]] = typer.Argument(None),
+    params: list[str] | None = typer.Argument(None),  # noqa: B008
     *,
-    plugin: Optional[Path] = None,
+    plugin: Path | None = None,
 ) -> None:
     """Run a single case of a given case handler type."""
     if plugin is not None:
@@ -64,7 +61,7 @@ def run(
     try:
         class_ = registry.get(case_handler_name)
     except CaseHandlerNotFound as e:
-        raise Abort(str(e))
+        raise Abort(str(e)) from e
 
     data = {}
     for param in params or []:

--- a/src/lembas/param.py
+++ b/src/lembas/param.py
@@ -89,12 +89,12 @@ class InputParameter:
         """
         try:
             return instance.__dict__[self._name]
-        except KeyError:
+        except KeyError as err:
             if self._default == _NoDefault:
                 raise AttributeError(
                     f"'{self._name}' attribute of '{owner.__name__}' class "
                     "has no default value and must be specified explicitly"
-                )
+                ) from err
             return self._default
 
     @cached_property

--- a/src/lembas/plugins.py
+++ b/src/lembas/plugins.py
@@ -42,10 +42,10 @@ class CaseHandlerRegistry:
         """
         try:
             return self._registry[name]
-        except KeyError:
+        except KeyError as err:
             raise CaseHandlerNotFound(
                 f"Could not find [bold]{name}[/bold] in the case handler registry"
-            )
+            ) from err
 
     def clear(self) -> None:
         """Clear the case handler registry."""
@@ -91,10 +91,9 @@ def load_plugins_from_file(plugin_path: Path) -> None:
     mod = _load_module_from_path(plugin_path)
 
     for name, obj in mod.__dict__.items():
-        if inspect.isclass(obj):
-            if issubclass(obj, Case) and obj != Case:
-                registry.add(obj)
-                print(f"Found [bold]{name}[/bold] in {plugin_path}")
+        if inspect.isclass(obj) and issubclass(obj, Case) and obj != Case:
+            registry.add(obj)
+            print(f"Found [bold]{name}[/bold] in {plugin_path}")
 
 
 hookspec = HookspecMarker("lembas")

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import weakref
+from collections.abc import Callable
 from functools import cached_property
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import TypeVar
 
 if TYPE_CHECKING:
@@ -31,9 +31,7 @@ class Results:
         """A reference to the parent case with which these results are associated."""
         parent = self._parent()
         if parent is None:  # pragma: no cover
-            raise ValueError(
-                "The parent has been de-referenced. This shouldn't happen."
-            )
+            raise ValueError("The parent has been de-referenced. This shouldn't happen.")
         return parent
 
     def __getattr__(self, item: str) -> Any:
@@ -44,7 +42,7 @@ class Results:
         cls = self.parent.__class__
         for method_name, method_func in cls.__dict__.items():
             try:
-                provides_results = getattr(method_func, "_provides_results")
+                provides_results = method_func._provides_results
             except AttributeError:
                 continue  # to next method
 
@@ -65,13 +63,13 @@ class Results:
                     "decorator."
                 )
 
-            for n, r in zip(provides_results, results):
+            for n, r in zip(provides_results, results, strict=True):
                 setattr(self, n, r)
 
         try:
             return self.__dict__[item]
-        except KeyError:
-            raise AttributeError(f"Result '{item}' is not defined")
+        except KeyError as err:
+            raise AttributeError(f"Result '{item}' is not defined") from err
 
     def get(self, item: str, default: Any = None) -> Any:
         """Dictionary-like get access."""
@@ -79,7 +77,7 @@ class Results:
 
 
 def result(
-    *func_or_names: Callable[[TCase], Any] | str
+    *func_or_names: Callable[[TCase], Any] | str,
 ) -> RawCaseMethod | Callable[[RawCaseMethod], RawCaseMethod]:
     """A decorator to annotate a method that provides result(s).
 
@@ -96,8 +94,8 @@ def result(
         # the decorated method.
         try:
             (method,) = func_or_names
-        except ValueError:  # pragma: no cover
-            raise ValueError("Must only provide a single callable")
+        except ValueError as err:  # pragma: no cover
+            raise ValueError("Must only provide a single callable") from err
         names = (method.__name__,)  # type: ignore
         method._provides_results = names  # type: ignore
         return method  # type: ignore

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -77,9 +77,7 @@ def test_case_parameter_type_conversion(case: MyCase, input_value: Any) -> None:
 
 
 @pytest.mark.parametrize("input_value", [1.0, 6.0])
-def test_case_parameter_bounds_raises_exception(
-    case: MyCase, input_value: float
-) -> None:
+def test_case_parameter_bounds_raises_exception(case: MyCase, input_value: float) -> None:
     """An exception is raised when attempting to set the value out of bounds."""
     with pytest.raises(ValueError):
         case.my_param = input_value
@@ -140,9 +138,7 @@ def test_string_condition_invalid_raises_exception(condition: str) -> None:
 def test_case_steps_order(case: MyCase) -> None:
     expected_steps = ["first_step", "second_step", "change_param_with_default"]
     # Extract the step names if they are expected (drop ones without a requires)
-    step_names = [
-        step.name for step in case._sorted_steps if step.name in expected_steps
-    ]
+    step_names = [step.name for step in case._sorted_steps if step.name in expected_steps]
     assert step_names == expected_steps
 
 
@@ -167,9 +163,7 @@ def test_case_lembas_toml(case: MyCase, tmp_path: Path) -> None:
     assert (tmp_path / "lembas" / "case.toml").exists()
     with (tmp_path / "lembas" / "case.toml").open("r") as fp:
         data = toml.load(fp)
-    assert data == {
-        "lembas": {"inputs": case.inputs, "case-handler": case.fully_resolved_name}
-    }
+    assert data == {"lembas": {"inputs": case.inputs, "case-handler": case.fully_resolved_name}}
 
 
 def test_case_relative_case_dir_is_absolute(case: MyCase, tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
-from typing import Callable
 
 import pytest
 from typer.testing import CliRunner


### PR DESCRIPTION
## Summary
Replace black, isort, and flake8 with ruff for linting and formatting.

- Remove `.flake8` config
- Remove `[tool.isort]` from pyproject.toml
- Add `[tool.ruff]` and `[tool.ruff.lint]` config
- Update pre-commit hooks to use ruff
- Apply ruff formatting to existing code

## Test plan
- [x] All tests pass
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes