### PR TITLE
fix: use with_version.py script for conda package versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         pixi-version: v0.44.0
         environments: build
     - name: Build conda package
-      run: VERSION=$(pixi run -e build python -m setuptools_scm) pixi run -e build build
+      run: pixi run -e build build
     - name: Upload the build artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -10,8 +10,10 @@ source:
 build:
   number: 0
   noarch: python
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION", "0.0.0") }}
   script:
-    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION", "0.0.0") }} python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,11 +1,8 @@
 schema_version: 1
 
-context:
-  version: ${{ VERSION | default("0.0.0") }}
-
 package:
   name: lembas
-  version: ${{ version }}
+  version: ${{ env.get("PKG_VERSION", "0.0.0") }}
 
 source:
   path: ..
@@ -14,7 +11,7 @@ build:
   number: 0
   noarch: python
   script:
-    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ version }} python -m pip install . -vv --no-deps --no-build-isolation
+    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION", "0.0.0") }} python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,7 +12,7 @@ rattler-build = "*"
 setuptools-scm = "*"
 
 [feature.build.tasks]
-build = "rattler-build build --recipe conda.recipe/ --output-dir dist/"
+build = "python scripts/with_version.py rattler-build build --recipe conda.recipe/ --output-dir dist/"
 upload = "anaconda --verbose --token $ANACONDA_ORG_TOKEN upload --user lembas-project $ANACONDA_LABEL --force"
 
 [feature.dev.dependencies]

--- a/scripts/with_version.py
+++ b/scripts/with_version.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Run a command with PKG_VERSION set from git tags.
+
+Usage:
+    python scripts/with_version.py                     # Print version only
+    python scripts/with_version.py <command> [args...] # Run command with PKG_VERSION set
+
+Examples:
+    python scripts/with_version.py
+    python scripts/with_version.py rattler-build build --recipe conda.recipe
+
+"""
+
+import os
+import subprocess
+import sys
+
+from setuptools_scm import get_version
+
+FALLBACK_VERSION = "0.0.0"
+
+
+def main() -> int:
+    try:
+        version = get_version()
+    except LookupError:
+        version = FALLBACK_VERSION
+
+    if len(sys.argv) < 2:
+        print(version)
+        return 0
+
+    print(f"PKG_VERSION={version}")
+
+    env = os.environ.copy()
+    env["PKG_VERSION"] = version
+
+    result = subprocess.run(sys.argv[1:], env=env, check=False)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/with_version.py` script that runs commands with `PKG_VERSION` env var set from git tags (using setuptools-scm)
- Updates `conda.recipe/recipe.yaml` to use `env.get("PKG_VERSION", "0.0.0")` instead of `VERSION`
- Updates pixi build task to use the script
- Simplifies the CI workflow (no more inline version extraction)

This fixes the conda package being built with version `0.0.0` instead of the correct version from git tags.

Based on the pattern from anaconda/anaconda-cli.

## Test plan
- [ ] CI builds conda package with correct version
- [ ] After merge, verify package on anaconda.org has proper version