### PR TITLE
fix: correct Jinja syntax for env.get and refactor workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-conda-package:
+    name: Build conda package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+    - name: Set up pixi
+      uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+      with:
+        pixi-version: v0.44.0
+        environments: build
+    - name: Build conda package
+      run: pixi run -e build build
+    - name: Upload the build artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: conda-${{ github.sha }}
+        path: dist/noarch/*.conda
+        if-no-files-found: error
+        retention-days: 7
+
+  build-wheel:
+    name: Build the wheel
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+    - name: Setup Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.14"
+    - name: Install build dependencies
+      run: pip install build
+    - name: Build the package
+      run: python -m build
+    - name: Upload the build artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: wheel-${{ github.sha }}
+        path: dist/*
+        if-no-files-found: error
+        retention-days: 7
+
+  check:
+    name: Check all builds successful
+    if: always()
+    needs: [build-conda-package, build-wheel]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether all required jobs succeeded or failed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,73 +1,12 @@
-name: "Publish"
+name: Publish
 
 on:
   workflow_call:
 
 jobs:
-  build-conda-package:
-    name: Build conda package
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0
-    - name: Set up pixi
-      uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
-      with:
-        pixi-version: v0.44.0
-        environments: build
-    - name: Build conda package
-      run: pixi run -e build build
-    - name: Upload the build artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: conda-${{ github.sha }}
-        path: dist/noarch/*.conda
-        if-no-files-found: error
-        retention-days: 7
-
-  build-wheel:
-    name: Build the wheel
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0
-    - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.14"
-    - name: Install build dependencies
-      run: pip install build
-    - name: Build the package
-      run: python -m build
-    - name: Upload the build artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: wheel-${{ github.sha }}
-        path: dist/*
-        if-no-files-found: error
-        retention-days: 7
-
-  # This check job runs to ensure all tests and builds  have passed, such that we can use it as a "wildcard"
-  # for branch protection to ensure all tests pass before a PR can be merged.
-  check:
-    name: Check all builds successful
-    if: always()
-    needs: [build-conda-package, build-wheel]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Decide whether all required jobs succeeded or failed
-      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
-
   publish-conda-pkg-to-anaconda-dot-org:
     name: Publish conda package to Anaconda.org
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'  # Only run on push to main branch
-    needs: [check]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up pixi
@@ -89,8 +28,6 @@ jobs:
   publish-wheel-to-anaconda-dot-org:
     name: Publish wheel to Anaconda.org
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'  # Only run on push to main branch
-    needs: [check]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Set up pixi
@@ -113,7 +50,6 @@ jobs:
     name: Publish wheel to PyPI
     if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [check]
     steps:
     - name: Checkout
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,14 @@ jobs:
       with:
         files: ./test-reports/coverage.xml
         env_vars: OS,PYTHON
-  # This check job runs to ensure all tests have passed, such that we can use it as a "wildcard" for branch
-  # protection to ensure all tests pass before a PR can be merged.
+  build:
+    uses: ./.github/workflows/build.yml
+
+  # This check job runs to ensure all tests and builds have passed, such that we can use it as a "wildcard"
+  # for branch protection to ensure all tests pass before a PR can be merged.
   check:
     if: always()
-    needs: [test]
+    needs: [test, build]
     runs-on: ubuntu-latest
     steps:
     - name: Decide whether all required jobs succeeded or failed

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -10,10 +10,8 @@ source:
 build:
   number: 0
   noarch: python
-  script_env:
-    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION") | default("0.0.0") }}
   script:
-    - python -m pip install . -vv --no-deps --no-build-isolation
+    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION") | default("0.0.0") }} python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 package:
   name: lembas
-  version: ${{ env.get("PKG_VERSION", "0.0.0") }}
+  version: ${{ env.get("PKG_VERSION") | default("0.0.0") }}
 
 source:
   path: ..
@@ -10,8 +10,10 @@ source:
 build:
   number: 0
   noarch: python
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION") | default("0.0.0") }}
   script:
-    - SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.get("PKG_VERSION", "0.0.0") }} python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
## Summary
- Fix recipe to use `env.get("PKG_VERSION") | default("0.0.0")` syntax (rattler-build doesn't support default as second arg)
- Add `script_env` for `SETUPTOOLS_SCM_PRETEND_VERSION` instead of inlining in script
- Split build jobs into separate `build.yml` workflow
- Build now runs on all PRs (not just main) to catch build issues early
- `publish.yml` now only handles publishing (no build jobs)

This fixes the conda package build failure on main.

## Test plan
- [ ] CI builds conda package successfully
- [ ] After merge, verify package on anaconda.org has proper version