### PR TITLE
feat: add release template and auto-labeling workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  categories:
+  - title: Breaking Changes
+    labels:
+    - breaking
+  - title: Features
+    labels:
+    - feat
+  - title: Bug Fixes
+    labels:
+    - fix
+  - title: Documentation
+    labels:
+    - docs
+  - title: Maintenance
+    labels:
+    - chore
+    - refactor
+    - ci
+    - build
+    - test
+  - title: Other Changes
+    labels:
+    - '*'
+  exclude:
+    labels:
+    - ignore-for-release

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,0 +1,59 @@
+# Automatically applies labels to PRs based on conventional commit prefixes in the title.
+# Labels are used by release.yml to categorize changes in auto-generated release notes.
+name: Auto-label PR
+
+on:
+  pull_request:
+    types:
+    - opened
+    - edited
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Add label to PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Apply conventional commit label
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3   # v9.0.0
+      with:
+        script: |
+          const title = context.payload.pull_request.title;
+
+          // Extract type from conventional commit format: type(scope): description
+          // The scope part '(scope)' is optional, but the colon is not.
+          const match = title.match(/^([a-z]+)(\(.*\))?:/);
+          if (!match) {
+            console.log('No conventional commit type found in title');
+            return;
+          }
+
+          const type = match[1];
+          console.log(`Found conventional commit type: ${type}`)
+
+          // Types to ignore (will get a special label)
+          const ignoredTypes = ['build'];
+
+          // Construct the label based on whether type is ignored or not.
+          // If not ignored, the type is used as the label.
+          const isIgnored = ignoredTypes.includes(type);
+          const label = isIgnored ? "ignore-for-release" : type;
+
+          try {
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label]
+            });
+            console.log(`Applied label: ${label}`);
+          } catch (error) {
+            console.log(`Failed to apply label "${label}": ${error.message}`);
+          }


### PR DESCRIPTION
## Summary
- Adds `.github/release.yml` for auto-generated release notes categorized by conventional commit type
- Adds `.github/workflows/auto-label.yaml` to automatically label PRs based on conventional commit prefix in title

This enables clean release notes when cutting releases like v0.1.0.

Based on patterns from anaconda/anaconda-cli.

## Test plan
- [ ] PR gets auto-labeled with `feat` label
- [ ] After merge, create a release and verify release notes are categorized