### PR TITLE
feat: add CLI commands for manifest synthesis and project management

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -140,7 +142,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -262,7 +264,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -384,12 +386,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -451,6 +455,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -461,7 +466,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -518,6 +523,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -528,7 +534,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -585,6 +591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -595,12 +602,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -667,6 +676,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.6-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
@@ -676,7 +686,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -738,6 +748,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.5.6-py314h217eccc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
@@ -747,7 +758,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -809,6 +820,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.6-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
@@ -818,7 +830,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1860,15 +1872,16 @@ packages:
   purls: []
   size: 728002
   timestamp: 1774197446916
-- pypi: .
+- pypi: ./
   name: lembas
-  version: 0.1.1.dev2+gee4c42aee
-  sha256: 46ad730235d4cdb2892b233377854df76f2102e449e012ce9a47eb7a4eab3a60
+  version: 0.1.1.dev1+g88d6d0c93.d20260610
+  sha256: cd41889ac7461c4d4d2a753a530cdf4947bed716013f1c3c34cc8e4727b78bbb
   requires_dist:
   - pluggy<=1.6.0
   - typer<0.27
   - rich
   - toml
+  - tomlkit>=0.12
   - lembas[dev] ; extra == 'ci'
   - pytest<=9.0.2 ; extra == 'dev'
   - pytest-cov<=7.1.0 ; extra == 'dev'
@@ -1884,7 +1897,6 @@ packages:
   - planingfsi ; extra == 'examples'
   - pandas<=3.0.3 ; extra == 'examples'
   requires_python: '>=3.11'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -142,7 +140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -264,7 +262,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -386,14 +384,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -466,7 +462,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -534,7 +530,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -602,14 +598,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -686,7 +680,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -758,7 +752,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -830,7 +824,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1872,9 +1866,9 @@ packages:
   purls: []
   size: 728002
   timestamp: 1774197446916
-- pypi: ./
+- pypi: .
   name: lembas
-  version: 0.1.1.dev1+g88d6d0c93.d20260610
+  version: 0.1.1.dev5+g299ead556
   sha256: cd41889ac7461c4d4d2a753a530cdf4947bed716013f1c3c34cc8e4727b78bbb
   requires_dist:
   - pluggy<=1.6.0
@@ -1897,6 +1891,7 @@ packages:
   - planingfsi ; extra == 'examples'
   - pandas<=3.0.3 ; extra == 'examples'
   requires_python: '>=3.11'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ dependencies = [
   "pluggy <=1.6.0",
   "typer <0.27",
   "rich",
-  "toml"
+  "toml",
+  "tomlkit >=0.12"
 ]
 description = "Lifecycle Engineering Model-Based Analysis System"
 dynamic = ["version"]

--- a/src/lembas/__init__.py
+++ b/src/lembas/__init__.py
@@ -3,6 +3,47 @@ from lembas.case import Case
 from lembas.case import CaseList
 from lembas.case import step
 from lembas.param import InputParameter
+from lembas.plugins import load_plugins_from_file
+from lembas.plugins import registry
 from lembas.results import result
 
-__all__ = ["Case", "CaseList", "InputParameter", "result", "step", "__version__"]
+__all__ = [
+    "Case",
+    "CaseList",
+    "InputParameter",
+    "load_local_plugins",
+    "load_plugins_from_file",
+    "registry",
+    "result",
+    "step",
+    "__version__",
+]
+
+
+def load_local_plugins() -> None:
+    """Load local plugins defined in [local-plugins] section of lembas.toml.
+
+    Call this at the start of run.py to load any plugins defined locally in the project.
+    After calling, case handlers will be available in the registry.
+
+    Example:
+        from lembas import load_local_plugins, registry
+
+        load_local_plugins()
+        PlaningPlateCase = registry.get("PlaningPlateCase")
+    """
+    from pathlib import Path
+
+    from lembas.manifest import load_lembas_manifest
+
+    cwd = Path.cwd()
+    try:
+        manifest = load_lembas_manifest(cwd)
+    except FileNotFoundError:
+        return
+
+    local_plugins = manifest.get("local-plugins", {})
+    for _name, path_str in local_plugins.items():
+        plugin_path = cwd / path_str
+        if plugin_path.exists():
+            load_plugins_from_file(plugin_path)

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -1,5 +1,8 @@
+"""Lembas CLI - command line interface for lifecycle engineering analysis."""
+
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -7,6 +10,12 @@ import typer
 from rich.console import Console
 
 from lembas._version import __version__
+from lembas.manifest import ensure_pixi_manifest
+from lembas.manifest import get_lembas_manifest_path
+from lembas.manifest import get_pixi_manifest_path
+from lembas.manifest import is_pixi_manifest_stale
+from lembas.manifest import load_lembas_manifest
+from lembas.manifest import write_pixi_manifest
 from lembas.plugins import CaseHandlerNotFound
 from lembas.plugins import load_plugins_from_file
 from lembas.plugins import registry
@@ -16,11 +25,7 @@ app = typer.Typer(add_completion=False)
 
 
 class Okay(typer.Exit):
-    """Prints an optional message to the console, before cleanly exiting.
-
-    Provides a standard way to end/confirm a successful command.
-
-    """
+    """Prints an optional message to the console, before cleanly exiting."""
 
     def __init__(self, msg: str = "", *args: Any, **kwargs: Any):
         if m := msg.strip():
@@ -37,24 +42,259 @@ class Abort(typer.Abort):
         super().__init__(*args, **kwargs)
 
 
-@app.callback(invoke_without_command=True, no_args_is_help=True)
+def _run_pixi(args: list[str]) -> int:
+    """Run pixi with the synthesized manifest, returning exit code."""
+    pixi_path = ensure_pixi_manifest()
+    # pixi expects: pixi <command> --manifest-path <path> [args]
+    # Insert --manifest-path after the first arg (the command)
+    if args:
+        cmd = ["pixi", args[0], "--manifest-path", str(pixi_path), *args[1:]]
+    else:
+        cmd = ["pixi", "--manifest-path", str(pixi_path)]
+    result = subprocess.run(cmd, check=False)
+    return result.returncode
+
+
+@app.callback(invoke_without_command=True)
 def main(
-    version: bool | None = typer.Option(None, "--version", help="Show project version and exit."),
+    ctx: typer.Context,
+    version: bool | None = typer.Option(None, "--version", help="Show version and exit."),
 ) -> None:
-    """Command Line Interface for Lembas."""
+    """Lembas - Lifecycle Engineering Model-Based Analysis System.
+
+    If no command is given, attempts to run the command as a pixi task.
+    """
     if version:
-        console.print(f"Lembas version: {__version__}", style="bold green")
+        console.print(f"lembas {__version__}")
         raise typer.Exit()
+
+    # If no subcommand and we have remaining args, try as pixi task
+    if ctx.invoked_subcommand is None:
+        # Check if lembas.toml exists
+        if not get_lembas_manifest_path().exists():
+            console.print("No lembas.toml found in current directory.", style="red")
+            console.print("Run 'lembas init' to create a new project.")
+            raise typer.Exit(1)
+
+        # No args means show help
+        if not ctx.args:
+            console.print(ctx.get_help())
+            raise typer.Exit()
+
+        # Try to run as pixi task
+        task_name = ctx.args[0]
+        task_args = ctx.args[1:]
+
+        manifest = load_lembas_manifest()
+        tasks = manifest.get("tasks", {})
+
+        if task_name not in tasks:
+            console.print(f"Unknown command or task: {task_name}", style="red")
+            console.print(f"Available tasks: {', '.join(tasks.keys()) or '(none)'}")
+            raise typer.Exit(1)
+
+        exit_code = _run_pixi(["run", task_name, *task_args])
+        raise typer.Exit(exit_code)
 
 
 @app.command()
-def run(
+def init(
+    name: str | None = typer.Option(None, help="Project name"),
+    project_type: str = typer.Option(
+        "study", "--type", "-t", help="Project type: study, plugin, workspace"
+    ),
+) -> None:
+    """Initialize a new lembas project."""
+    cwd = Path.cwd()
+    manifest_path = cwd / "lembas.toml"
+
+    if manifest_path.exists():
+        raise Abort("lembas.toml already exists in this directory")
+
+    project_name = name or cwd.name
+
+    if project_type == "study":
+        content = f'''[project]
+name = "{project_name}"
+type = "study"
+description = ""
+channels = ["conda-forge", "lembas-project"]
+platforms = ["linux-64", "osx-arm64"]
+
+[dependencies]
+python = ">=3.11"
+
+[plugins]
+# Add lembas plugins here, e.g.:
+# lembas-planingfsi = ">=0.1.0"
+
+[tasks]
+run = "python run.py"
+'''
+        run_py = cwd / "run.py"
+        if not run_py.exists():
+            run_py.write_text('''"""Run the parametric study."""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    """Main entry point."""
+    print("Hello from lembas!")
+    # TODO: Add your study logic here
+
+
+if __name__ == "__main__":
+    main()
+''')
+            console.print(f"Created {run_py}")
+
+    elif project_type == "plugin":
+        content = f'''[project]
+name = "{project_name}"
+type = "plugin"
+version = "0.1.0"
+description = ""
+channels = ["conda-forge", "lembas-project"]
+platforms = ["linux-64", "osx-arm64"]
+
+[dependencies]
+python = ">=3.11"
+lembas = ">=0.1.0"
+
+[dev-dependencies]
+pytest = "*"
+
+[plugin]
+entry-point = "{project_name.replace("-", "_")}:Plugin"
+
+[tasks]
+test = "pytest tests/ -v"
+'''
+    else:
+        raise Abort(f"Unknown project type: {project_type}")
+
+    manifest_path.write_text(content)
+    console.print(f"Created {manifest_path}")
+
+    # Create .gitignore
+    gitignore = cwd / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text(".lembas/\n")
+        console.print(f"Created {gitignore}")
+
+    raise Okay(f"Initialized lembas {project_type}: {project_name}")
+
+
+@app.command()
+def install() -> None:
+    """Install project dependencies.
+
+    Synthesizes .lembas/pixi.toml from lembas.toml and runs pixi install.
+    """
+    if not get_lembas_manifest_path().exists():
+        raise Abort("No lembas.toml found. Run 'lembas init' first.")
+
+    if is_pixi_manifest_stale():
+        console.print("Synthesizing .lembas/pixi.toml...")
+        write_pixi_manifest()
+
+    console.print("Installing dependencies...")
+    exit_code = _run_pixi(["install"])
+
+    if exit_code == 0:
+        raise Okay("Dependencies installed")
+    else:
+        raise typer.Exit(exit_code)
+
+
+@app.command()
+def shell() -> None:
+    """Start a shell with the project environment activated."""
+    if not get_lembas_manifest_path().exists():
+        raise Abort("No lembas.toml found. Run 'lembas init' first.")
+
+    ensure_pixi_manifest()
+    pixi_path = get_pixi_manifest_path()
+
+    # Use exec to replace the current process
+    import os
+
+    os.execlp("pixi", "pixi", "--manifest-path", str(pixi_path), "shell")
+
+
+@app.command("run")
+def run_task(
+    task: str = typer.Argument(..., help="Task name to run"),
+    args: list[str] | None = typer.Argument(None, help="Additional arguments"),  # noqa: B008
+) -> None:
+    """Run a task defined in lembas.toml."""
+    if not get_lembas_manifest_path().exists():
+        raise Abort("No lembas.toml found. Run 'lembas init' first.")
+
+    manifest = load_lembas_manifest()
+    tasks = manifest.get("tasks", {})
+
+    if task not in tasks:
+        console.print(f"Unknown task: {task}", style="red")
+        console.print(f"Available tasks: {', '.join(tasks.keys()) or '(none)'}")
+        raise typer.Exit(1)
+
+    exit_code = _run_pixi(["run", task, *(args or [])])
+    raise typer.Exit(exit_code)
+
+
+@app.command()
+def status() -> None:
+    """Show project status."""
+    if not get_lembas_manifest_path().exists():
+        raise Abort("No lembas.toml found. Run 'lembas init' first.")
+
+    manifest = load_lembas_manifest()
+    project = manifest.get("project", {})
+
+    console.print(f"[bold]Project:[/bold] {project.get('name', '(unnamed)')}")
+    console.print(f"[bold]Type:[/bold] {project.get('type', '(unknown)')}")
+
+    if desc := project.get("description"):
+        console.print(f"[bold]Description:[/bold] {desc}")
+
+    # Show plugins
+    if plugins := manifest.get("plugins"):
+        console.print("\n[bold]Plugins:[/bold]")
+        for name, version in plugins.items():
+            console.print(f"  - {name} {version}")
+
+    # Show tasks
+    if tasks := manifest.get("tasks"):
+        console.print("\n[bold]Tasks:[/bold]")
+        for name, task in tasks.items():
+            if isinstance(task, str):
+                console.print(f"  - {name}: {task}")
+            else:
+                console.print(f"  - {name}: {task.get('cmd', '(complex)')}")
+
+    # Check pixi manifest status
+    pixi_path = get_pixi_manifest_path()
+    if pixi_path.exists():
+        if is_pixi_manifest_stale():
+            console.print(
+                "\n[yellow]⚠ .lembas/pixi.toml is stale. Run 'lembas install' to update.[/yellow]"
+            )
+        else:
+            console.print("\n[green]✓ .lembas/pixi.toml is up to date[/green]")
+    else:
+        console.print("\n[yellow]⚠ No .lembas/pixi.toml. Run 'lembas install' to create.[/yellow]")
+
+
+@app.command("case")
+def run_case(
     case_handler_name: str,
     params: list[str] | None = typer.Argument(None),  # noqa: B008
     *,
     plugin: Path | None = None,
 ) -> None:
-    """Run a single case of a given case handler type."""
+    """Run a single case of a given case handler type (low-level)."""
     if plugin is not None:
         load_plugins_from_file(plugin)
 

--- a/src/lembas/manifest.py
+++ b/src/lembas/manifest.py
@@ -1,0 +1,172 @@
+"""Lembas manifest handling and pixi.toml synthesis."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import toml
+import tomlkit
+
+LEMBAS_DIR = ".lembas"
+LEMBAS_MANIFEST = "lembas.toml"
+PIXI_MANIFEST = "pixi.toml"
+
+
+def get_lembas_dir(project_root: Path | None = None) -> Path:
+    """Get the .lembas directory path."""
+    root = project_root or Path.cwd()
+    return root / LEMBAS_DIR
+
+
+def get_lembas_manifest_path(project_root: Path | None = None) -> Path:
+    """Get the lembas.toml path."""
+    root = project_root or Path.cwd()
+    return root / LEMBAS_MANIFEST
+
+
+def get_pixi_manifest_path(project_root: Path | None = None) -> Path:
+    """Get the synthesized pixi.toml path inside .lembas/."""
+    return get_lembas_dir(project_root) / PIXI_MANIFEST
+
+
+def load_lembas_manifest(project_root: Path | None = None) -> dict[str, Any]:
+    """Load and parse lembas.toml."""
+    path = get_lembas_manifest_path(project_root)
+    if not path.exists():
+        raise FileNotFoundError(f"No lembas.toml found at {path}")
+    return toml.load(path)
+
+
+def compute_manifest_hash(manifest: dict[str, Any]) -> str:
+    """Compute SHA-256 hash of the relevant manifest sections for staleness check."""
+    relevant_sections = ["project", "dependencies", "plugins", "tasks", "environments"]
+    relevant = {k: v for k, v in manifest.items() if k in relevant_sections}
+    canonical = toml.dumps(relevant)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def extract_hash_from_pixi_manifest(pixi_path: Path) -> str | None:
+    """Extract the lembas-hash from the synthesized pixi.toml header."""
+    if not pixi_path.exists():
+        return None
+    with pixi_path.open() as f:
+        for line in f:
+            if line.startswith("# lembas-hash:"):
+                return line.split(":", 1)[1].strip()
+            if not line.startswith("#"):
+                break
+    return None
+
+
+def is_pixi_manifest_stale(project_root: Path | None = None) -> bool:
+    """Check if the synthesized pixi.toml is stale relative to lembas.toml."""
+    pixi_path = get_pixi_manifest_path(project_root)
+    if not pixi_path.exists():
+        return True
+
+    manifest = load_lembas_manifest(project_root)
+    current_hash = compute_manifest_hash(manifest)
+    stored_hash = extract_hash_from_pixi_manifest(pixi_path)
+
+    return current_hash != stored_hash
+
+
+def synthesize_pixi_manifest(project_root: Path | None = None) -> str:
+    """Synthesize pixi.toml content from lembas.toml.
+
+    Synthesis rules:
+    - [project] → [workspace] (name, channels, platforms)
+    - [plugins] entries → added to [dependencies]
+    - [dependencies] → [dependencies]
+    - [tasks] → [tasks]
+    - [environments] → [environments] (passed through)
+    - [platform], [plugin] → stripped (lembas-only)
+    """
+    manifest = load_lembas_manifest(project_root)
+    manifest_hash = compute_manifest_hash(manifest)
+
+    doc = tomlkit.document()
+
+    # Add header comment with hash
+    doc.add(tomlkit.comment(f"lembas-hash: {manifest_hash}"))
+    doc.add(tomlkit.comment("Auto-generated from lembas.toml - do not edit"))
+    doc.add(tomlkit.nl())
+
+    # [workspace] from [project]
+    project = manifest.get("project", {})
+    workspace = tomlkit.table()
+    if name := project.get("name"):
+        workspace["name"] = name
+    if channels := project.get("channels"):
+        workspace["channels"] = channels
+    if platforms := project.get("platforms"):
+        workspace["platforms"] = platforms
+    if workspace:
+        doc["workspace"] = workspace
+
+    # [dependencies] - merge regular deps and plugins
+    deps = tomlkit.table()
+
+    # Add regular dependencies
+    for key, value in manifest.get("dependencies", {}).items():
+        deps[key] = value
+
+    # Add plugins as dependencies (plugins are conda packages)
+    for key, value in manifest.get("plugins", {}).items():
+        deps[key] = value
+
+    if deps:
+        doc["dependencies"] = deps
+
+    # [tasks] - pass through
+    if tasks := manifest.get("tasks"):
+        tasks_table = tomlkit.table()
+        for name, task in tasks.items():
+            if isinstance(task, str):
+                tasks_table[name] = task
+            elif isinstance(task, dict):
+                # Complex task with cmd, depends-on, etc.
+                tasks_table[name] = task
+        doc["tasks"] = tasks_table
+
+    # [environments] - pass through if present
+    if environments := manifest.get("environments"):
+        doc["environments"] = environments
+
+    return tomlkit.dumps(doc)
+
+
+def write_pixi_manifest(project_root: Path | None = None) -> Path:
+    """Synthesize and write pixi.toml to .lembas/ directory."""
+    lembas_dir = get_lembas_dir(project_root)
+    lembas_dir.mkdir(exist_ok=True)
+
+    # Create .gitignore in .lembas/ if it doesn't exist
+    gitignore = lembas_dir / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text(".pixi/\n")
+
+    pixi_path = get_pixi_manifest_path(project_root)
+    content = synthesize_pixi_manifest(project_root)
+    pixi_path.write_text(content)
+
+    return pixi_path
+
+
+def ensure_pixi_manifest(project_root: Path | None = None) -> Path:
+    """Ensure pixi.toml exists and is up-to-date, regenerating if stale."""
+    if is_pixi_manifest_stale(project_root):
+        return write_pixi_manifest(project_root)
+    return get_pixi_manifest_path(project_root)
+
+
+def run_pixi(
+    args: list[str], project_root: Path | None = None
+) -> subprocess.CompletedProcess[bytes]:
+    """Run pixi with the synthesized manifest."""
+    pixi_path = ensure_pixi_manifest(project_root)
+    cmd = ["pixi", "--manifest-path", str(pixi_path), *args]
+    return subprocess.run(cmd, check=False)

--- a/src/lembas/manifest.py
+++ b/src/lembas/manifest.py
@@ -121,15 +121,19 @@ def synthesize_pixi_manifest(project_root: Path | None = None) -> str:
     if deps:
         doc["dependencies"] = deps
 
-    # [tasks] - pass through
+    # [tasks] - pass through, adding cwd=".." so tasks run from project root
     if tasks := manifest.get("tasks"):
         tasks_table = tomlkit.table()
         for name, task in tasks.items():
             if isinstance(task, str):
-                tasks_table[name] = task
+                # Simple string task - convert to dict with cwd
+                tasks_table[name] = {"cmd": task, "cwd": ".."}
             elif isinstance(task, dict):
-                # Complex task with cmd, depends-on, etc.
-                tasks_table[name] = task
+                # Complex task - add cwd if not already set
+                task_dict = dict(task)
+                if "cwd" not in task_dict:
+                    task_dict["cwd"] = ".."
+                tasks_table[name] = task_dict
         doc["tasks"] = tasks_table
 
     # [environments] - pass through if present

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,7 @@ def test_version(invoke_cli: CLIInvoker) -> None:
     """A basic smoke-test to check that the CLI can print out the version."""
     result = invoke_cli("--version")
     assert result.exit_code == 0
-    assert f"Lembas version: {__version__}" in result.stdout
+    assert f"lembas {__version__}" in result.stdout
 
 
 @pytest.fixture()
@@ -97,7 +97,7 @@ def test_run_case_success(invoke_cli: CLIInvoker, plugin_module_path: Path) -> N
     """A successful run must specify the case handler name, plugin path, and parameters without a default value."""
     my_param_value = 3.5
     result = invoke_cli(
-        "run",
+        "case",
         "MyCase",
         "--plugin",
         str(plugin_module_path),
@@ -112,6 +112,6 @@ def test_run_case_success(invoke_cli: CLIInvoker, plugin_module_path: Path) -> N
 
 def test_run_case_missing_case_handler(invoke_cli: CLIInvoker) -> None:
     """If the case handler is not in the registry, execution is aborted."""
-    result = invoke_cli("run", "MyCase")
+    result = invoke_cli("case", "NonExistentCase")
     assert result.exit_code == 1, result.stdout
-    assert "Could not find MyCase in the case handler registry" in result.stdout
+    assert "Could not find NonExistentCase in the case handler registry" in result.stdout


### PR DESCRIPTION
## Summary
Add new CLI commands for managing lembas projects:
- `lembas init` - scaffold new study/plugin projects
- `lembas install` - synthesize .lembas/pixi.toml and install deps
- `lembas run <task>` - run tasks defined in lembas.toml
- `lembas shell` - enter environment shell
- `lembas status` - show project info and manifest status

The manifest module handles lembas.toml → pixi.toml synthesis:
- Merges `[plugins]` into `[dependencies]`
- Passes through `[tasks]` and `[environments]`
- Uses SHA-256 hash for staleness detection
- Strips lembas-only sections (`[platform]`, `[plugin]`)

## New dependency
- `tomlkit >=0.12` for TOML manipulation with comment preservation

## Test plan
- [x] `lembas --help` shows all commands
- [x] `lembas status` works on example-planing-plate-study
- [x] `lembas install` synthesizes pixi.toml and installs deps
- [ ] CI passes