### PR TITLE
feat: add load_cases for loading case definitions from YAML

### DIFF
--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -26,6 +26,7 @@ requirements:
     - rich
     - toml
     - pydantic >=2.0
+    - pyyaml >=6.0
     - tomlkit >=0.12
 
 tests:

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -140,7 +142,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -262,7 +264,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -384,12 +386,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -453,6 +457,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -462,7 +467,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -521,6 +526,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -530,7 +536,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -589,6 +595,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.26.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -598,12 +605,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -680,7 +689,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -752,7 +761,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -824,7 +833,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1866,16 +1875,17 @@ packages:
   purls: []
   size: 728002
   timestamp: 1774197446916
-- pypi: .
+- pypi: ./
   name: lembas
-  version: 0.1.1.dev5+g299ead556
-  sha256: cd41889ac7461c4d4d2a753a530cdf4947bed716013f1c3c34cc8e4727b78bbb
+  version: 0.1.2.dev0+gb1a8ccd12.d20260708
+  sha256: 0a18f403479b11187cd160ad2d68acea855c03f8721b4c998c812f7b74f178d5
   requires_dist:
   - pluggy<=1.6.0
   - typer<0.27
   - rich
   - toml
   - tomlkit>=0.12
+  - pyyaml>=6.0
   - lembas[dev] ; extra == 'ci'
   - pytest<=9.0.2 ; extra == 'dev'
   - pytest-cov<=7.1.0 ; extra == 'dev'
@@ -1891,7 +1901,6 @@ packages:
   - planingfsi ; extra == 'examples'
   - pandas<=3.0.3 ; extra == 'examples'
   requires_python: '>=3.11'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275
@@ -4129,6 +4138,17 @@ packages:
   - pkg:pypi/typer?source=hash-mapping
   size: 185949
   timestamp: 1780494828822
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260518-pyhcf101f3_0.conda
+  sha256: 58eb35e905356d7105db51e1cd7eb5a9f2029e0d0bb345215c0eb525babaffb4
+  md5: 8c9d908beae2f052bf188c41c85f0b80
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0 AND MIT
+  purls:
+  - pkg:pypi/types-pyyaml?source=hash-mapping
+  size: 26875
+  timestamp: 1779101988372
 - conda: https://conda.anaconda.org/conda-forge/noarch/types-toml-0.10.8.20260518-pyhcf101f3_0.conda
   sha256: 368352daaccc2ac88a614835195f8492b7b986cda23e634f5bbf5cbdc1dc7e48
   md5: c34839dee9c06aa5bff05f9b23053695

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -142,7 +140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -264,7 +262,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
@@ -386,14 +384,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -467,7 +463,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -536,7 +532,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -605,14 +601,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -689,7 +683,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -761,7 +755,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -833,7 +827,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1875,9 +1869,9 @@ packages:
   purls: []
   size: 728002
   timestamp: 1774197446916
-- pypi: ./
+- pypi: .
   name: lembas
-  version: 0.1.2.dev0+gb1a8ccd12.d20260708
+  version: 0.1.2.dev2+g2c53899f4
   sha256: 0a18f403479b11187cd160ad2d68acea855c03f8721b4c998c812f7b74f178d5
   requires_dist:
   - pluggy<=1.6.0
@@ -1901,6 +1895,7 @@ packages:
   - planingfsi ; extra == 'examples'
   - pandas<=3.0.3 ; extra == 'examples'
   requires_python: '>=3.11'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,6 @@
 [dependencies]
 python = ">=3.11"
+pyyaml = ">=6.0"
 
 [environments]
 build = {features = ["build"], solve-group = "default"}
@@ -25,6 +26,7 @@ pre-commit = ">=4.0"
 pytest = ">=8.0"
 pytest-cov = "*"
 ruff = "*"
+types-pyyaml = "*"
 types-toml = "*"
 
 [feature.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
   "typer <0.27",
   "rich",
   "toml",
-  "tomlkit >=0.12"
+  "tomlkit >=0.12",
+  "pyyaml >=6.0"
 ]
 description = "Lifecycle Engineering Model-Based Analysis System"
 dynamic = ["version"]

--- a/src/lembas/__init__.py
+++ b/src/lembas/__init__.py
@@ -6,11 +6,13 @@ from lembas.param import InputParameter
 from lembas.plugins import load_plugins_from_file
 from lembas.plugins import registry
 from lembas.results import result
+from lembas.study import load_cases
 
 __all__ = [
     "Case",
     "CaseList",
     "InputParameter",
+    "load_cases",
     "load_local_plugins",
     "load_plugins_from_file",
     "registry",

--- a/src/lembas/study.py
+++ b/src/lembas/study.py
@@ -1,0 +1,136 @@
+"""Study configuration and case loading from YAML files."""
+
+from __future__ import annotations
+
+from itertools import product
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+
+import yaml
+
+from lembas.case import CaseList
+from lembas.manifest import get_lembas_manifest_path
+from lembas.manifest import load_lembas_manifest
+from lembas.plugins import registry
+
+if TYPE_CHECKING:
+    from lembas.case import Case
+
+__all__ = ["load_cases"]
+
+
+def load_cases(
+    cases_path: Path | str | None = None,
+    project_root: Path | None = None,
+) -> CaseList[Case]:
+    """Load case definitions from a YAML file.
+
+    If no path is provided, reads `[study].cases` from lembas.toml to find the cases file.
+
+    Args:
+        cases_path: Path to a YAML file containing case definitions. If None, reads
+            from lembas.toml's [study].cases setting.
+        project_root: Project root directory containing lembas.toml. Defaults to cwd.
+
+    Returns:
+        A CaseList populated with the case instances.
+
+    The YAML file should contain a list of case definitions:
+
+    ```yaml
+    - handler: PlaningPlateCase
+      expansion: cartesian
+      parameters:
+        froude_num: [0.5, 1.0, 1.5, 2.0]
+        angle_of_attack: [5.0, 7.5, 10.0]
+
+    - handler: AnotherCase
+      expansion: zip
+      parameters:
+        param_a: [1, 2, 3]
+        param_b: [4, 5, 6]
+    ```
+
+    Expansion strategies:
+    - "cartesian": Cartesian product of all parameter arrays (default)
+    - "zip": Pair parameters by index (all arrays must have same length)
+    - "explicit": Single case with scalar parameter values
+
+    """
+    if cases_path is None:
+        manifest_path = get_lembas_manifest_path(project_root)
+        manifest = load_lembas_manifest(project_root)
+        study_config = manifest.get("study", {})
+        cases_file = study_config.get("cases")
+
+        if cases_file is None:
+            return CaseList()
+
+        resolved_path = manifest_path.parent / cases_file
+    else:
+        resolved_path = Path(cases_path)
+
+    with resolved_path.open() as f:
+        cases_config = yaml.safe_load(f) or []
+
+    return _expand_cases(cases_config)
+
+
+def _expand_cases(cases_config: list[dict[str, Any]]) -> CaseList[Case]:
+    """Expand case definitions into a CaseList."""
+    cases: CaseList[Case] = CaseList()
+
+    for case_def in cases_config:
+        handler_name = case_def["handler"]
+        expansion = case_def.get("expansion", "cartesian")
+        parameters = case_def.get("parameters", {})
+
+        handler_cls = registry.get(handler_name)
+
+        if expansion == "cartesian":
+            _expand_cartesian(cases, handler_cls, parameters)
+        elif expansion == "zip":
+            _expand_zip(cases, handler_cls, parameters)
+        elif expansion == "explicit":
+            cases.add(handler_cls(**parameters))
+        else:
+            raise ValueError(f"Unknown expansion strategy: {expansion}")
+
+    return cases
+
+
+def _expand_cartesian(
+    cases: CaseList[Case],
+    handler_cls: type[Case],
+    parameters: dict[str, Any],
+) -> None:
+    """Expand parameters using Cartesian product."""
+    param_names = list(parameters.keys())
+    param_values = [v if isinstance(v, list) else [v] for v in parameters.values()]
+
+    for combo in product(*param_values):
+        params = dict(zip(param_names, combo, strict=True))
+        cases.add(handler_cls(**params))
+
+
+def _expand_zip(
+    cases: CaseList[Case],
+    handler_cls: type[Case],
+    parameters: dict[str, Any],
+) -> None:
+    """Expand parameters by zipping arrays together."""
+    param_names = list(parameters.keys())
+    param_values = list(parameters.values())
+    lengths = [len(v) if isinstance(v, list) else 1 for v in param_values]
+
+    if len(set(lengths)) > 1:
+        raise ValueError(
+            f"All parameter arrays must have same length for 'zip' expansion. "
+            f"Got lengths: {dict(zip(param_names, lengths, strict=True))}"
+        )
+
+    param_values = [v if isinstance(v, list) else [v] for v in param_values]
+    for values in zip(*param_values, strict=True):
+        params = dict(zip(param_names, values, strict=True))
+        cases.add(handler_cls(**params))

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,0 +1,202 @@
+"""Tests for study.py - case loading from YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+from lembas import Case
+from lembas import InputParameter
+from lembas.plugins import registry
+from lembas.study import load_cases
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+class DummyCase(Case):
+    """Test case handler for study tests."""
+
+    param_a = InputParameter(type=float)
+    param_b = InputParameter(type=float, default=1.0)
+
+
+@pytest.fixture(autouse=True)
+def setup_registry() -> None:
+    """Register the test case handler."""
+    registry.clear()
+    registry.add(DummyCase)
+
+
+@pytest.fixture()
+def tmp_project(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
+    """Create a temporary project directory."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_load_cases_cartesian(tmp_project: Path) -> None:
+    """Cartesian expansion creates product of all parameters."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          expansion: cartesian
+          parameters:
+            param_a: [1.0, 2.0]
+            param_b: [10.0, 20.0]
+        """)
+    )
+
+    cases = load_cases(cases_yaml)
+
+    assert len(cases) == 4
+    params = [(c.param_a, c.param_b) for c in cases]  # type: ignore[attr-defined]
+    assert (1.0, 10.0) in params
+    assert (1.0, 20.0) in params
+    assert (2.0, 10.0) in params
+    assert (2.0, 20.0) in params
+
+
+def test_load_cases_zip(tmp_project: Path) -> None:
+    """Zip expansion pairs parameters by index."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          expansion: zip
+          parameters:
+            param_a: [1.0, 2.0, 3.0]
+            param_b: [10.0, 20.0, 30.0]
+        """)
+    )
+
+    cases = load_cases(cases_yaml)
+
+    assert len(cases) == 3
+    params = [(c.param_a, c.param_b) for c in cases]  # type: ignore[attr-defined]
+    assert params == [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)]
+
+
+def test_load_cases_zip_mismatched_lengths(tmp_project: Path) -> None:
+    """Zip expansion raises error if arrays have different lengths."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          expansion: zip
+          parameters:
+            param_a: [1.0, 2.0]
+            param_b: [10.0, 20.0, 30.0]
+        """)
+    )
+
+    with pytest.raises(ValueError, match="same length"):
+        load_cases(cases_yaml)
+
+
+def test_load_cases_explicit(tmp_project: Path) -> None:
+    """Explicit expansion creates a single case with scalar values."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          expansion: explicit
+          parameters:
+            param_a: 1.5
+            param_b: 2.5
+        """)
+    )
+
+    cases = load_cases(cases_yaml)
+
+    assert len(cases) == 1
+    assert cases._cases[0].param_a == 1.5  # type: ignore[attr-defined]
+    assert cases._cases[0].param_b == 2.5  # type: ignore[attr-defined]
+
+
+def test_load_cases_multiple_definitions(tmp_project: Path) -> None:
+    """Multiple case definitions are combined."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          expansion: cartesian
+          parameters:
+            param_a: [1.0, 2.0]
+            param_b: [10.0]
+
+        - handler: DummyCase
+          expansion: explicit
+          parameters:
+            param_a: 99.0
+        """)
+    )
+
+    cases = load_cases(cases_yaml)
+
+    assert len(cases) == 3  # 2 from cartesian + 1 from explicit
+
+
+def test_load_cases_from_manifest(tmp_project: Path) -> None:
+    """Load cases via lembas.toml reference."""
+    lembas_toml = tmp_project / "lembas.toml"
+    lembas_toml.write_text(
+        dedent("""\
+        [project]
+        name = "test"
+        type = "study"
+
+        [study]
+        cases = "my_cases.yaml"
+        """)
+    )
+
+    cases_yaml = tmp_project / "my_cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          parameters:
+            param_a: [1.0, 2.0]
+        """)
+    )
+
+    cases = load_cases()
+
+    assert len(cases) == 2
+
+
+def test_load_cases_default_expansion_is_cartesian(tmp_project: Path) -> None:
+    """Default expansion strategy is cartesian."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          parameters:
+            param_a: [1.0, 2.0]
+            param_b: [10.0, 20.0]
+        """)
+    )
+
+    cases = load_cases(cases_yaml)
+
+    assert len(cases) == 4  # Cartesian product
+
+
+def test_load_cases_unknown_expansion(tmp_project: Path) -> None:
+    """Unknown expansion strategy raises error."""
+    cases_yaml = tmp_project / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: DummyCase
+          expansion: unknown
+          parameters:
+            param_a: [1.0]
+        """)
+    )
+
+    with pytest.raises(ValueError, match="Unknown expansion strategy"):
+        load_cases(cases_yaml)


### PR DESCRIPTION
## Summary

- Adds `load_cases()` function to load case definitions from YAML files
- Supports three expansion strategies: `cartesian`, `zip`, `explicit`
- Cases file path is referenced from `[study].cases` in lembas.toml
- Adds pyyaml as a dependency

## Usage

**cases.yaml:**
```yaml
- handler: PlaningPlateCase
  expansion: cartesian
  parameters:
    froude_num: [0.5, 1.0, 1.5, 2.0]
    angle_of_attack: [5.0, 7.5, 10.0]

- handler: PlaningPlateCase
  expansion: zip
  parameters:
    froude_num: [2.5, 3.0]
    angle_of_attack: [2.0, 3.0]
```

**lembas.toml:**
```toml
[study]
cases = "cases.yaml"
```

**run.py:**
```python
from lembas import load_local_plugins, load_cases

load_local_plugins()
cases = load_cases()
cases.run_all()
```

## Test plan

- [x] Unit tests for all expansion strategies
- [x] Test loading via lembas.toml reference
- [x] Test error handling for mismatched zip lengths
- [x] Test unknown expansion strategy error