### PR TITLE
feat: make `lembas run` without args run study cases

### DIFF
--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -225,12 +225,21 @@ def shell() -> None:
 
 @app.command("run")
 def run_task(
-    task: str = typer.Argument(..., help="Task name to run"),
+    task: str | None = typer.Argument(None, help="Task name to run, or omit to run cases"),
     args: list[str] | None = typer.Argument(None, help="Additional arguments"),  # noqa: B008
 ) -> None:
-    """Run a task defined in lembas.toml."""
+    """Run cases or a task defined in lembas.toml.
+
+    Without arguments, loads and runs all cases from [study].cases.
+    With a task name, runs that pixi task.
+    """
     if not get_lembas_manifest_path().exists():
         raise Abort("No lembas.toml found. Run 'lembas init' first.")
+
+    # If no task specified, run the study cases
+    if task is None:
+        _run_study_cases()
+        return
 
     manifest = load_lembas_manifest()
     tasks = manifest.get("tasks", {})
@@ -242,6 +251,29 @@ def run_task(
 
     exit_code = _run_pixi(["run", task, *(args or [])])
     raise typer.Exit(exit_code)
+
+
+def _run_study_cases() -> None:
+    """Load and run all cases defined in [study].cases."""
+    from lembas import load_local_plugins
+    from lembas.study import load_cases
+
+    manifest = load_lembas_manifest()
+    study_config = manifest.get("study", {})
+
+    if "cases" not in study_config:
+        raise Abort("No [study].cases defined in lembas.toml")
+
+    # Load local plugins first
+    load_local_plugins()
+
+    # Load and run cases
+    cases = load_cases()
+    console.print(f"Running {len(cases)} cases...")
+
+    cases.run_all()
+
+    raise Okay(f"Completed {len(cases)} cases")
 
 
 @app.command()

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -262,7 +262,7 @@ def _run_study_cases() -> None:
     study_config = manifest.get("study", {})
 
     if "cases" not in study_config:
-        raise Abort("No [study].cases defined in lembas.toml")
+        raise Abort("No \\[study].cases defined in lembas.toml")
 
     # Load local plugins first
     load_local_plugins()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,3 +115,83 @@ def test_run_case_missing_case_handler(invoke_cli: CLIInvoker) -> None:
     result = invoke_cli("case", "NonExistentCase")
     assert result.exit_code == 1, result.stdout
     assert "Could not find NonExistentCase in the case handler registry" in result.stdout
+
+
+def test_run_without_args_runs_study_cases(
+    invoke_cli: CLIInvoker, run_path: Path, plugin_module_path: Path
+) -> None:
+    """Running `lembas run` without args loads and runs cases from [study].cases."""
+    # Create lembas.toml with study config
+    lembas_toml = run_path / "lembas.toml"
+    lembas_toml.write_text(
+        dedent(f"""\
+        [project]
+        name = "test-study"
+        type = "study"
+
+        [local-plugins]
+        my_mod = "{plugin_module_path.name}"
+
+        [study]
+        cases = "cases.yaml"
+        """)
+    )
+
+    # Create cases.yaml
+    cases_yaml = run_path / "cases.yaml"
+    cases_yaml.write_text(
+        dedent("""\
+        - handler: MyCase
+          expansion: explicit
+          parameters:
+            my_param: 3.0
+        """)
+    )
+
+    result = invoke_cli("run")
+
+    assert result.exit_code == 0, result.stdout
+    assert "Running 1 cases" in result.stdout
+    assert "Completed 1 cases" in result.stdout
+
+
+def test_run_without_args_no_study_cases_errors(invoke_cli: CLIInvoker, run_path: Path) -> None:
+    """Running `lembas run` without [study].cases shows an error."""
+    # Create lembas.toml without study.cases
+    lembas_toml = run_path / "lembas.toml"
+    lembas_toml.write_text(
+        dedent("""\
+        [project]
+        name = "test-study"
+        type = "study"
+        """)
+    )
+
+    result = invoke_cli("run")
+
+    assert result.exit_code == 1, result.stdout
+    assert "[study].cases" in result.stdout
+
+
+def test_run_with_task_runs_pixi_task(invoke_cli: CLIInvoker, run_path: Path) -> None:
+    """Running `lembas run <task>` still runs a pixi task."""
+    # Create lembas.toml with a task
+    lembas_toml = run_path / "lembas.toml"
+    lembas_toml.write_text(
+        dedent("""\
+        [project]
+        name = "test-study"
+        type = "study"
+        channels = ["conda-forge"]
+        platforms = ["linux-64", "osx-arm64"]
+
+        [tasks]
+        hello = "echo hello"
+        """)
+    )
+
+    result = invoke_cli("run", "nonexistent")
+
+    # Task doesn't exist, so we get an error
+    assert result.exit_code == 1
+    assert "Unknown task: nonexistent" in result.stdout


### PR DESCRIPTION
## Summary

- `lembas run` without arguments now loads local plugins and runs all cases from `[study].cases`
- `lembas run <task>` continues to run pixi tasks as before

This makes `run.py` optional for simple studies. A minimal study now only needs:
- `lembas.toml` with `[study].cases = "cases.yaml"`
- `cases.yaml` with case definitions

## Example

```bash
# Before: needed run.py
lembas run run

# After: just run cases directly
lembas run
```

## Test plan

- [x] Existing CLI tests pass
- [x] Type checking passes
- [ ] Manual test with example-planing-plate-study