### PR TITLE
refactor: use lembas _run-cases in synthesized pixi task

### DIFF
--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -313,6 +313,21 @@ def status() -> None:
         console.print("\n[yellow]⚠ No .lembas/pixi.toml. Run 'lembas install' to create.[/yellow]")
 
 
+@app.command("_run-cases", hidden=True)
+def run_cases_internal() -> None:
+    """Internal command to run study cases (called by synthesized pixi task)."""
+    from lembas import load_local_plugins
+    from lembas.study import load_cases
+
+    load_local_plugins()
+    cases = load_cases()
+
+    console.print(f"Running {len(cases)} cases...")
+    cases.run_all()
+
+    raise Okay(f"Completed {len(cases)} cases")
+
+
 @app.command("case")
 def run_case(
     case_handler_name: str,

--- a/src/lembas/manifest.py
+++ b/src/lembas/manifest.py
@@ -127,17 +127,8 @@ def synthesize_pixi_manifest(project_root: Path | None = None) -> str:
     # Inject _lembas_run task if [study].cases is defined
     study_config = manifest.get("study", {})
     if "cases" in study_config:
-        # Use inline Python to avoid version dependency on lembas CLI
-        run_script = (
-            "from lembas import load_local_plugins, load_cases; "
-            "load_local_plugins(); "
-            "cases = load_cases(); "
-            "print(f'Running {len(cases)} cases...'); "
-            "cases.run_all(); "
-            "print(f'Completed {len(cases)} cases')"
-        )
         tasks_table["_lembas_run"] = {
-            "cmd": f'python -c "{run_script}"',
+            "cmd": "lembas _run-cases",
             "cwd": "..",
         }
 


### PR DESCRIPTION
## Summary
- Add hidden `_run-cases` CLI command for use by synthesized pixi task
- Simplifies the generated task from inline Python to `lembas _run-cases`
- Command is hidden from `--help` since it's internal

## Before
```toml
[tasks._lembas_run]
cmd = "python -c \"from lembas import load_local_plugins, load_cases; ...\""
```

## After
```toml
[tasks._lembas_run]
cmd = "lembas _run-cases"
```

## Test plan
- [x] Unit tests pass (52 passed, 1 skipped)