### PR TITLE
feat: use lembas.lock at project root for lockfile

### DIFF
--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from lembas._version import __version__
 from lembas.manifest import ensure_pixi_manifest
 from lembas.manifest import get_lembas_manifest_path
+from lembas.manifest import get_lockfile_path
 from lembas.manifest import get_pixi_manifest_path
 from lembas.manifest import is_pixi_manifest_stale
 from lembas.manifest import load_lembas_manifest
@@ -43,14 +44,29 @@ class Abort(typer.Abort):
 
 
 def _run_pixi(args: list[str]) -> int:
-    """Run pixi with the synthesized manifest, returning exit code."""
+    """Run pixi with the synthesized manifest and lockfile, returning exit code."""
     pixi_path = ensure_pixi_manifest()
-    # pixi expects: pixi <command> --manifest-path <path> [args]
-    # Insert --manifest-path after the first arg (the command)
+    lockfile_path = get_lockfile_path()
+    # pixi expects: pixi <command> --manifest-path <path> --lockfile-path <path> [args]
+    # Insert flags after the first arg (the command)
     if args:
-        cmd = ["pixi", args[0], "--manifest-path", str(pixi_path), *args[1:]]
+        cmd = [
+            "pixi",
+            args[0],
+            "--manifest-path",
+            str(pixi_path),
+            "--lockfile-path",
+            str(lockfile_path),
+            *args[1:],
+        ]
     else:
-        cmd = ["pixi", "--manifest-path", str(pixi_path)]
+        cmd = [
+            "pixi",
+            "--manifest-path",
+            str(pixi_path),
+            "--lockfile-path",
+            str(lockfile_path),
+        ]
     result = subprocess.run(cmd, check=False)
     return result.returncode
 
@@ -216,11 +232,20 @@ def shell() -> None:
 
     ensure_pixi_manifest()
     pixi_path = get_pixi_manifest_path()
+    lockfile_path = get_lockfile_path()
 
     # Use exec to replace the current process
     import os
 
-    os.execlp("pixi", "pixi", "--manifest-path", str(pixi_path), "shell")
+    os.execlp(
+        "pixi",
+        "pixi",
+        "--manifest-path",
+        str(pixi_path),
+        "--lockfile-path",
+        str(lockfile_path),
+        "shell",
+    )
 
 
 @app.command("run")

--- a/src/lembas/manifest.py
+++ b/src/lembas/manifest.py
@@ -12,6 +12,7 @@ import tomlkit
 
 LEMBAS_DIR = ".lembas"
 LEMBAS_MANIFEST = "lembas.toml"
+LEMBAS_LOCK = "lembas.lock"
 PIXI_MANIFEST = "pixi.toml"
 
 
@@ -30,6 +31,12 @@ def get_lembas_manifest_path(project_root: Path | None = None) -> Path:
 def get_pixi_manifest_path(project_root: Path | None = None) -> Path:
     """Get the synthesized pixi.toml path inside .lembas/."""
     return get_lembas_dir(project_root) / PIXI_MANIFEST
+
+
+def get_lockfile_path(project_root: Path | None = None) -> Path:
+    """Get the lembas.lock path at project root."""
+    root = project_root or Path.cwd()
+    return root / LEMBAS_LOCK
 
 
 def load_lembas_manifest(project_root: Path | None = None) -> dict[str, Any]:
@@ -181,7 +188,15 @@ def ensure_pixi_manifest(project_root: Path | None = None) -> Path:
 def run_pixi(
     args: list[str], project_root: Path | None = None
 ) -> subprocess.CompletedProcess[bytes]:
-    """Run pixi with the synthesized manifest."""
+    """Run pixi with the synthesized manifest and lockfile at project root."""
     pixi_path = ensure_pixi_manifest(project_root)
-    cmd = ["pixi", "--manifest-path", str(pixi_path), *args]
+    lockfile_path = get_lockfile_path(project_root)
+    cmd = [
+        "pixi",
+        "--manifest-path",
+        str(pixi_path),
+        "--lockfile-path",
+        str(lockfile_path),
+        *args,
+    ]
     return subprocess.run(cmd, check=False)


### PR DESCRIPTION
## Summary
- Pass `--lockfile-path` to all pixi invocations
- Lockfile written to `lembas.lock` at project root instead of `.lembas/pixi.lock`
- Users see `lembas.toml` + `lembas.lock`, pixi remains an implementation detail

## Test plan
- [x] Unit tests pass (52 passed, 1 skipped)