### PR TITLE
fix: use symlink for lembas.lock instead of --lockfile-path

### DIFF
--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -12,7 +12,6 @@ from rich.console import Console
 from lembas._version import __version__
 from lembas.manifest import ensure_pixi_manifest
 from lembas.manifest import get_lembas_manifest_path
-from lembas.manifest import get_lockfile_path
 from lembas.manifest import get_pixi_manifest_path
 from lembas.manifest import is_pixi_manifest_stale
 from lembas.manifest import load_lembas_manifest
@@ -44,29 +43,14 @@ class Abort(typer.Abort):
 
 
 def _run_pixi(args: list[str]) -> int:
-    """Run pixi with the synthesized manifest and lockfile, returning exit code."""
+    """Run pixi with the synthesized manifest, returning exit code."""
     pixi_path = ensure_pixi_manifest()
-    lockfile_path = get_lockfile_path()
-    # pixi expects: pixi <command> --manifest-path <path> --lockfile-path <path> [args]
-    # Insert flags after the first arg (the command)
+    # pixi expects: pixi <command> --manifest-path <path> [args]
+    # Insert --manifest-path after the first arg (the command)
     if args:
-        cmd = [
-            "pixi",
-            args[0],
-            "--manifest-path",
-            str(pixi_path),
-            "--lockfile-path",
-            str(lockfile_path),
-            *args[1:],
-        ]
+        cmd = ["pixi", args[0], "--manifest-path", str(pixi_path), *args[1:]]
     else:
-        cmd = [
-            "pixi",
-            "--manifest-path",
-            str(pixi_path),
-            "--lockfile-path",
-            str(lockfile_path),
-        ]
+        cmd = ["pixi", "--manifest-path", str(pixi_path)]
     result = subprocess.run(cmd, check=False)
     return result.returncode
 
@@ -232,20 +216,11 @@ def shell() -> None:
 
     ensure_pixi_manifest()
     pixi_path = get_pixi_manifest_path()
-    lockfile_path = get_lockfile_path()
 
     # Use exec to replace the current process
     import os
 
-    os.execlp(
-        "pixi",
-        "pixi",
-        "--manifest-path",
-        str(pixi_path),
-        "--lockfile-path",
-        str(lockfile_path),
-        "shell",
-    )
+    os.execlp("pixi", "pixi", "--manifest-path", str(pixi_path), "shell")
 
 
 @app.command("run")

--- a/src/lembas/manifest.py
+++ b/src/lembas/manifest.py
@@ -162,14 +162,23 @@ def synthesize_pixi_manifest(project_root: Path | None = None) -> str:
 
 
 def write_pixi_manifest(project_root: Path | None = None) -> Path:
-    """Synthesize and write pixi.toml to .lembas/ directory."""
+    """Synthesize and write pixi.toml to .lembas/ directory.
+
+    Also creates a symlink from .lembas/pixi.lock -> ../lembas.lock so that
+    the lockfile appears at project root where users can commit it.
+    """
     lembas_dir = get_lembas_dir(project_root)
     lembas_dir.mkdir(exist_ok=True)
 
     # Create .gitignore in .lembas/ if it doesn't exist
     gitignore = lembas_dir / ".gitignore"
     if not gitignore.exists():
-        gitignore.write_text(".pixi/\n")
+        gitignore.write_text(".pixi/\npixi.lock\n")
+
+    # Create symlink for lockfile: .lembas/pixi.lock -> ../lembas.lock
+    pixi_lock_path = lembas_dir / "pixi.lock"
+    if not pixi_lock_path.exists() and not pixi_lock_path.is_symlink():
+        pixi_lock_path.symlink_to(f"../{LEMBAS_LOCK}")
 
     pixi_path = get_pixi_manifest_path(project_root)
     content = synthesize_pixi_manifest(project_root)
@@ -188,15 +197,7 @@ def ensure_pixi_manifest(project_root: Path | None = None) -> Path:
 def run_pixi(
     args: list[str], project_root: Path | None = None
 ) -> subprocess.CompletedProcess[bytes]:
-    """Run pixi with the synthesized manifest and lockfile at project root."""
+    """Run pixi with the synthesized manifest."""
     pixi_path = ensure_pixi_manifest(project_root)
-    lockfile_path = get_lockfile_path(project_root)
-    cmd = [
-        "pixi",
-        "--manifest-path",
-        str(pixi_path),
-        "--lockfile-path",
-        str(lockfile_path),
-        *args,
-    ]
+    cmd = ["pixi", "--manifest-path", str(pixi_path), *args]
     return subprocess.run(cmd, check=False)


### PR DESCRIPTION
## Summary
- The `--lockfile-path` flag doesn't exist in pixi
- Instead, create a symlink from `.lembas/pixi.lock -> ../lembas.lock`
- Pixi writes the lockfile through the symlink to project root
- Users see `lembas.lock` at project root which they can commit

## Test plan
- [x] Unit tests pass (52 passed, 1 skipped)
- [x] Manually tested symlink approach works with pixi