### PR TITLE
feat: add default case directory convention with nesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ venv.bak/
 # Example case outputs
 /examples/**/cases/
 
+# Test case outputs
+/cases/
+
 # Generated documentation
 /docs/build/
 /docs/source/api/

--- a/docs/adr/0001-case-directory-convention.md
+++ b/docs/adr/0001-case-directory-convention.md
@@ -1,0 +1,65 @@
+# ADR 0001: Case Directory Convention
+
+## Status
+
+Accepted
+
+## Context
+
+Engineers need to browse case directories by parameter values. Plugin authors previously
+had to implement `case_dir` themselves, leading to inconsistency and boilerplate.
+
+## Decision
+
+### Directory structure
+
+- Default: `cases/{p1}={v1}/{p2}={v2}/{p3}={v3}/`
+- Nest first 3 parameters by **declaration order** (good for human browsing)
+- Subclasses can override `case_dir` property for full control
+
+### InputParameter additions
+
+- `path_format`: format spec for values in paths (default `.6g` for floats)
+- `short_name`: optional alias for shorter directory names
+
+```python
+froude_num = InputParameter(
+    type=float,
+    min=0.2,
+    max=3.0,
+    path_format=".2f",   # renders as "0.50" not "0.5"
+    short_name="Fr",     # renders as "Fr=0.50" not "froude_num=0.50"
+)
+```
+
+### Case identification
+
+- `case.id` = full SHA-256 of `handler_fqn + ":" + canonical_json(inputs)` (64 hex chars)
+- `case.short_id` = first 8 characters of `id` (for display)
+- Inputs sorted **alphabetically** for deterministic hashing
+- Declaration order for paths, alphabetical for IDs — different concerns
+
+### Index file
+
+- `.lembas/cases.json` maps `id` (full hash) to `{path, handler, all_paths}`
+- **Cache only**, not source of truth
+- Source of truth: `lembas/case.toml` inside each case directory
+- Tracks duplicate paths (same id at multiple locations) via `all_paths`
+- Auto-reindexes when stale (disk count differs from indexed count)
+
+### CLI commands
+
+- `lembas cases list`: show cases with status, handler, and notes (duplicates, path mismatches)
+- `lembas cases list --pending`: filter to pending cases only
+- `lembas cases list --complete`: filter to complete cases only
+- `lembas cases reindex`: rebuild index from case.toml files
+- `lembas cases clean`: remove stale entries (prompts for confirmation)
+- `lembas cases clean --force`: remove stale entries without prompting
+
+## Consequences
+
+- Plugin authors get sensible defaults without boilerplate
+- Human-readable directory structure for browsing
+- Content-addressed IDs enable platform deduplication
+- Index-as-cache pattern tolerates manual directory changes
+- Automatic staleness detection keeps index in sync with filesystem

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import inspect
 import itertools
+import json
 import logging
 import types
 from collections.abc import Callable
@@ -128,25 +130,57 @@ class Case:
         return mod_prefix + cls.__qualname__
 
     @cached_property
-    def case_dir(self) -> Path | None:
-        """An optional property that can be set for a subclass.
+    def id(self) -> str:
+        """Content-addressed case identifier.
 
-        If set, the lembas case.toml file will be written in this directory.
-
+        SHA-256 of handler FQN + canonical JSON of inputs (sorted alphabetically).
+        Full 64-character hex string. Used for platform sync and deduplication.
         """
-        return None
+        canonical = json.dumps(self.inputs, sort_keys=True, separators=(",", ":"))
+        content = f"{self.fully_resolved_name}:{canonical}"
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    @property
+    def short_id(self) -> str:
+        """Short form of id for display (first 8 characters)."""
+        return self.id[:8]
+
+    @classmethod
+    def _get_input_parameters_by_declaration_order(cls) -> list[InputParameter]:
+        """Get InputParameters in their declaration order.
+
+        Only includes parameters that are part of case inputs (excludes control parameters).
+        """
+        params = []
+        for value in cls.__dict__.values():
+            if isinstance(value, InputParameter) and value.include_in_inputs_dict:
+                params.append(value)
+        return params
 
     @cached_property
-    def relative_case_dir(self) -> Path | None:
+    def case_dir(self) -> Path:
+        """Working directory for this case.
+
+        Default: cases/{param1}={value1}/{param2}={value2}/{param3}={value3}/
+        Nests first 3 parameters by declaration order. Override in subclass for custom paths.
+        """
+        parts = ["cases"]
+        params = self._get_input_parameters_by_declaration_order()
+
+        for param in params[:3]:
+            name = param.path_name
+            value = param.format_for_path(getattr(self, param._name))
+            parts.append(f"{name}={value}")
+
+        return Path.cwd() / Path(*parts)
+
+    @cached_property
+    def relative_case_dir(self) -> Path:
         """Return a case directory relative to current working directory if possible.
 
         If the case directory is not a subdirectory of current working directory, the absolute
         path is returned.
-
         """
-        if self.case_dir is None:
-            return None
-
         try:
             return self.case_dir.relative_to(Path.cwd())
         except ValueError:
@@ -175,9 +209,6 @@ class Case:
 
     def _write_lembas_file(self) -> None:
         """Write a file in the case directory specifying the case handler and all input values used."""
-        if self.relative_case_dir is None:
-            return None
-
         case_summary_file = self.relative_case_dir / LEMBAS_CASE_TOML_FILENAME
         case_summary_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -193,10 +224,32 @@ class Case:
         decorated with ``@step``.
 
         """
+        self._check_index_sync()
         self.log("Running %s", self)
         self._write_lembas_file()
         for step_method in self._sorted_steps:
             step_method(self)
+
+    def _check_index_sync(self) -> None:
+        """Warn if the indexed path for this id differs from computed case_dir."""
+        from lembas.index import get_case_dir_from_index
+        from lembas.index import update_case_index
+
+        handler_name = self.fully_resolved_name.split(".")[-1]
+        indexed_path = get_case_dir_from_index(self.id)
+        if indexed_path is not None:
+            if indexed_path.resolve() != self.case_dir.resolve():
+                self.log(
+                    "Warning: case %s indexed at %s but computed case_dir is %s. "
+                    "Run 'lembas cases reindex' to update.",
+                    self.short_id,
+                    indexed_path,
+                    self.case_dir,
+                    level=logging.WARNING,
+                )
+        else:
+            # Not in index yet, add it
+            update_case_index(self.id, self.case_dir, handler=handler_name)
 
 
 class CaseList(Generic[TCase]):

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import typer
 from rich.console import Console
+from rich.table import Table
 
 from lembas._version import __version__
 from lembas.manifest import ensure_pixi_manifest
@@ -22,6 +23,10 @@ from lembas.plugins import registry
 
 console = Console()
 app = typer.Typer(add_completion=False)
+
+# Subcommand group for case management
+cases_app = typer.Typer(help="Manage study cases")
+app.add_typer(cases_app, name="cases")
 
 
 class Okay(typer.Exit):
@@ -328,7 +333,9 @@ def run_cases_internal() -> None:
     raise Okay(f"Completed {len(cases)} cases")
 
 
-@app.command("case")
+# TODO: Merge this into `lembas run --handler <name>` and deprecate this command.
+# See: https://github.com/lembas-project/lembas-core/issues/180
+@app.command("case", hidden=True)
 def run_case(
     case_handler_name: str,
     params: list[str] | None = typer.Argument(None),  # noqa: B008
@@ -355,3 +362,138 @@ def run_case(
     case.run()
 
     raise Okay("Case complete")
+
+
+def _print_cases_table(cases: list) -> None:
+    """Print a table of cases with styled status and notes."""
+    from lembas.index import CaseStatus
+
+    status_styles = {
+        CaseStatus.COMPLETE: "[green]complete[/green]",
+        CaseStatus.MISSING: "[red]missing[/red]",
+        CaseStatus.PENDING: "[yellow]pending[/yellow]",
+    }
+
+    table = Table(title="Cases")
+    table.add_column("ID", style="cyan")
+    table.add_column("HANDLER")
+    table.add_column("STATUS")
+    table.add_column("PATH")
+    table.add_column("NOTES")
+
+    for case in cases:
+        styled_status = status_styles.get(case.status, case.status.value)
+        styled_notes = f"[yellow]{case.notes}[/yellow]" if case.notes else ""
+        table.add_row(case.short_id, case.handler, styled_status, case.path, styled_notes)
+
+    console.print(table)
+
+
+@cases_app.callback(invoke_without_command=True)
+def cases_callback(ctx: typer.Context) -> None:
+    """Manage study cases."""
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
+
+
+@cases_app.command("list")
+def cases_list(
+    pending: bool = typer.Option(False, "--pending", "-p", help="Show only pending cases"),
+    complete: bool = typer.Option(False, "--complete", "-c", help="Show only complete cases"),
+) -> None:
+    """List all cases (specified and run) with their status.
+
+    By default shows all cases from cases.yaml and any that have been run.
+    Use --pending or --complete to filter (mutually exclusive).
+    """
+    from lembas.index import CaseStatus
+    from lembas.index import ensure_index_fresh
+    from lembas.index import gather_case_info
+    from lembas.index import load_specified_cases
+
+    if pending and complete:
+        raise Abort("--pending and --complete are mutually exclusive")
+
+    # Load index, auto-reindex if stale
+    index, was_reindexed = ensure_index_fresh()
+    if was_reindexed:
+        console.print("[dim]Index stale, reindexed.[/dim]")
+
+    # Load specified cases from cases.yaml
+    specified_result = load_specified_cases()
+    if specified_result.warning:
+        console.print(f"[yellow]Warning: {specified_result.warning}[/yellow]\n")
+
+    # Determine filter
+    filter_status = None
+    if pending:
+        filter_status = CaseStatus.PENDING
+    elif complete:
+        filter_status = CaseStatus.COMPLETE
+
+    # Gather case info
+    cases = gather_case_info(index, specified_result.cases, filter_status)
+
+    if not cases and not index and not specified_result.cases:
+        console.print("No cases found. Add cases to cases.yaml or run 'lembas run'.")
+        return
+
+    _print_cases_table(cases)
+
+
+@cases_app.command("reindex")
+def cases_reindex() -> None:
+    """Rebuild index from case.toml files.
+
+    Scans for case.toml files, extracts handler and inputs,
+    recomputes case IDs, and rebuilds .lembas/cases.json.
+    """
+    from lembas.index import CASE_TOML_PATH
+    from lembas.index import reindex_cases
+
+    console.print(f"Scanning cases/**/{CASE_TOML_PATH}...")
+    index = reindex_cases()
+    console.print(f"Found {len(index)} cases, rebuilt index.")
+
+
+@cases_app.command("clean")
+def cases_clean(
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
+) -> None:
+    """Clean up stale index entries and remove duplicate path references.
+
+    Removes index entries where the path no longer exists.
+    Shows what will be cleaned and prompts for confirmation unless --force is used.
+    """
+    from lembas.index import clean_index
+    from lembas.index import load_case_index
+    from lembas.index import save_case_index
+
+    if not load_case_index():
+        console.print("Index is empty, nothing to clean.")
+        return
+
+    result = clean_index()
+
+    # Print what will be cleaned
+    for short_id, path in result.stale_entries:
+        console.print(f"[red]STALE:[/red] {short_id} -> {path} (no existing paths)")
+    for short_id, removed in result.pruned_entries:
+        console.print(f"[yellow]PRUNE:[/yellow] {short_id} removed {removed} missing path(s)")
+
+    if result.is_clean:
+        console.print("[green]Index is clean, no changes needed.[/green]")
+        return
+
+    # Prompt for confirmation unless --force
+    if not force:
+        console.print(f"\nWill remove {len(result.stale_entries)} stale entries.")
+        confirm = typer.confirm("Proceed?")
+        if not confirm:
+            console.print("Aborted.")
+            return
+
+    save_case_index(result.cleaned_index)
+    console.print(
+        f"[green]Cleaned index:[/green] removed {len(result.stale_entries)} stale entries."
+    )

--- a/src/lembas/index.py
+++ b/src/lembas/index.py
@@ -1,0 +1,405 @@
+"""Case index management for mapping case IDs to directory paths."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import toml
+
+__all__ = [
+    "load_case_index",
+    "save_case_index",
+    "get_case_dir_from_index",
+    "update_case_index",
+    "reindex_cases",
+    "ensure_index_fresh",
+    "gather_case_info",
+    "load_specified_cases",
+    "clean_index",
+    "CaseInfo",
+    "CaseStatus",
+    "CleanResult",
+    "SpecifiedCasesResult",
+    "CASE_TOML_PATH",
+]
+
+LEMBAS_DIR = Path(".lembas")
+CASES_INDEX_FILE = LEMBAS_DIR / "cases.json"
+CASE_TOML_PATH = Path("lembas") / "case.toml"
+
+
+class CaseStatus(Enum):
+    """Status of a case."""
+
+    COMPLETE = "complete"
+    MISSING = "missing"
+    PENDING = "pending"
+
+
+@dataclass
+class CaseInfo:
+    """Information about a case for display purposes."""
+
+    id: str
+    short_id: str
+    handler: str
+    path: str
+    status: CaseStatus
+    notes: str
+
+
+def load_case_index(project_root: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Load case index from .lembas/cases.json.
+
+    Args:
+        project_root: Project root directory. Defaults to current working directory.
+
+    Returns:
+        Dictionary mapping case_id to {path, handler, duplicates?}.
+        For backwards compatibility, also handles old format (case_id -> path string).
+    """
+    root = project_root or Path.cwd()
+    index_file = root / CASES_INDEX_FILE
+    if not index_file.exists():
+        return {}
+    raw = json.loads(index_file.read_text())
+    # Handle old format: case_id -> path string
+    if raw and isinstance(next(iter(raw.values())), str):
+        return {k: {"path": v, "handler": ""} for k, v in raw.items()}
+    return raw
+
+
+def save_case_index(index: dict[str, dict[str, Any]], project_root: Path | None = None) -> None:
+    """Save case index to .lembas/cases.json.
+
+    Args:
+        index: Dictionary mapping case_id to {path, handler, duplicates?}.
+        project_root: Project root directory. Defaults to current working directory.
+    """
+    root = project_root or Path.cwd()
+    index_file = root / CASES_INDEX_FILE
+    index_file.parent.mkdir(parents=True, exist_ok=True)
+    index_file.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n")
+
+
+def get_case_dir_from_index(case_id: str, project_root: Path | None = None) -> Path | None:
+    """Look up case directory from index, verify it exists.
+
+    Args:
+        case_id: The content-addressed case identifier.
+        project_root: Project root directory. Defaults to current working directory.
+
+    Returns:
+        Path to the case directory if found and exists, None otherwise.
+    """
+    root = project_root or Path.cwd()
+    index = load_case_index(root)
+    if case_id in index:
+        entry = index[case_id]
+        path = root / entry["path"]
+        if path.exists():
+            return path
+    return None
+
+
+def update_case_index(
+    case_id: str,
+    case_dir: Path,
+    handler: str = "",
+    project_root: Path | None = None,
+) -> None:
+    """Add or update a case in the index.
+
+    Args:
+        case_id: The content-addressed case identifier.
+        case_dir: Path to the case directory.
+        handler: Handler class name.
+        project_root: Project root directory. Defaults to current working directory.
+    """
+    root = project_root or Path.cwd()
+    index = load_case_index(root)
+    try:
+        relative_path = str(case_dir.relative_to(root))
+    except ValueError:
+        relative_path = str(case_dir)
+
+    if case_id in index:
+        # Update path, keep track of all paths
+        entry = index[case_id]
+        entry["path"] = relative_path
+        if relative_path not in entry.get("all_paths", []):
+            entry.setdefault("all_paths", []).append(relative_path)
+    else:
+        index[case_id] = {
+            "path": relative_path,
+            "handler": handler,
+            "all_paths": [relative_path],
+        }
+    save_case_index(index, root)
+
+
+def compute_case_id(handler_fqn: str, inputs: dict) -> str:
+    """Compute case ID from handler name and inputs.
+
+    Args:
+        handler_fqn: Fully qualified name of the case handler.
+        inputs: Dictionary of input parameter values.
+
+    Returns:
+        Full 64-character hex string (SHA-256).
+    """
+    canonical = json.dumps(inputs, sort_keys=True, separators=(",", ":"))
+    content = f"{handler_fqn}:{canonical}"
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def reindex_cases(
+    cases_root: Path | None = None,
+    project_root: Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Scan case.toml files and rebuild the index.
+
+    Searches for lembas/case.toml files under the cases directory, extracts
+    the handler and inputs from each, recomputes the case ID, and rebuilds
+    the index file.
+
+    Args:
+        cases_root: Root directory to scan for cases. Defaults to "cases" under project_root.
+        project_root: Project root directory. Defaults to current working directory.
+
+    Returns:
+        The rebuilt index mapping case_id to {path, handler, all_paths}.
+    """
+    root = project_root or Path.cwd()
+    cases_dir = cases_root or (root / "cases")
+
+    index: dict[str, dict[str, Any]] = {}
+
+    if not cases_dir.exists():
+        save_case_index(index, root)
+        return index
+
+    for case_toml in cases_dir.rglob(str(CASE_TOML_PATH)):
+        case_dir = case_toml.parent.parent
+        try:
+            data = toml.loads(case_toml.read_text())
+            handler_fqn = data["lembas"]["case-handler"]
+            inputs = data["lembas"]["inputs"]
+            case_id = compute_case_id(handler_fqn, inputs)
+            try:
+                relative_path = str(case_dir.relative_to(root))
+            except ValueError:
+                relative_path = str(case_dir)
+
+            handler_name = handler_fqn.split(".")[-1]
+
+            if case_id in index:
+                # Track all paths for this case_id
+                index[case_id]["all_paths"].append(relative_path)
+            else:
+                index[case_id] = {
+                    "path": relative_path,
+                    "handler": handler_name,
+                    "all_paths": [relative_path],
+                }
+        except (KeyError, toml.TomlDecodeError):
+            continue
+
+    save_case_index(index, root)
+    return index
+
+
+def ensure_index_fresh(project_root: Path | None = None) -> tuple[dict[str, dict[str, Any]], bool]:
+    """Load index, auto-reindexing if stale.
+
+    Args:
+        project_root: Project root directory. Defaults to current working directory.
+
+    Returns:
+        Tuple of (index, was_reindexed).
+    """
+    root = project_root or Path.cwd()
+    cases_dir = root / "cases"
+    index = load_case_index(root)
+
+    if not index:
+        if cases_dir.exists() and any(cases_dir.rglob(str(CASE_TOML_PATH))):
+            return reindex_cases(project_root=root), True
+        return index, False
+
+    if cases_dir.exists():
+        disk_count = sum(1 for _ in cases_dir.rglob(str(CASE_TOML_PATH)))
+        index_path_count = sum(len(e.get("all_paths", [e["path"]])) for e in index.values())
+        if disk_count != index_path_count:
+            return reindex_cases(project_root=root), True
+
+    return index, False
+
+
+def gather_case_info(
+    index: dict[str, dict[str, Any]],
+    specified_cases: dict[str, tuple[str, str]] | None = None,
+    filter_status: CaseStatus | None = None,
+) -> list[CaseInfo]:
+    """Gather case information from index and specified cases.
+
+    Args:
+        index: The case index mapping id to {path, handler, all_paths}.
+        specified_cases: Optional dict of id -> (handler, expected_path) from cases.yaml.
+        filter_status: Optional status to filter by.
+
+    Returns:
+        List of CaseInfo objects sorted by path.
+    """
+    specified = specified_cases or {}
+    all_ids = set(index.keys()) | set(specified.keys())
+    cases: list[CaseInfo] = []
+
+    for case_id in all_ids:
+        if case_id in index:
+            entry = index[case_id]
+            path = entry["path"]
+            handler = entry.get("handler", "")
+            all_paths = entry.get("all_paths", [path])
+            path_exists = Path(path).exists()
+
+            # Check for duplicates
+            notes = ""
+            if len(all_paths) > 1:
+                notes = f"+{len(all_paths) - 1} duplicate(s)"
+
+            # Check if matches specified case
+            if case_id in specified:
+                specified_handler, specified_path = specified[case_id]
+                handler = handler or specified_handler
+                if path != specified_path:
+                    notes = f"expected: {specified_path}"
+
+            status = CaseStatus.COMPLETE if path_exists else CaseStatus.MISSING
+            if not handler:
+                handler = "-"
+        else:
+            # In specified but not run
+            handler, path = specified[case_id]
+            status = CaseStatus.PENDING
+            notes = ""
+
+        if filter_status and status != filter_status:
+            continue
+
+        cases.append(
+            CaseInfo(
+                id=case_id,
+                short_id=case_id[:8],
+                handler=handler,
+                path=path,
+                status=status,
+                notes=notes,
+            )
+        )
+
+    cases.sort(key=lambda c: c.path)
+    return cases
+
+
+@dataclass
+class SpecifiedCasesResult:
+    """Result of loading specified cases from cases.yaml."""
+
+    cases: dict[str, tuple[str, str]]  # id -> (handler_name, expected_path)
+    warning: str | None  # Warning message if loading failed partially
+
+
+def load_specified_cases() -> SpecifiedCasesResult:
+    """Load specified cases from cases.yaml.
+
+    Returns:
+        SpecifiedCasesResult with cases dict and optional warning.
+    """
+    from lembas.manifest import load_lembas_manifest
+
+    specified: dict[str, tuple[str, str]] = {}
+    warning: str | None = None
+
+    try:
+        manifest = load_lembas_manifest()
+        if "study" in manifest and "cases" in manifest["study"]:
+            from lembas import load_local_plugins
+            from lembas.study import load_cases
+
+            load_local_plugins()
+            case_list = load_cases()
+            for case in case_list:
+                specified[case.id] = (
+                    case.fully_resolved_name.split(".")[-1],
+                    str(case.relative_case_dir),
+                )
+    except FileNotFoundError:
+        pass
+    except (ImportError, ModuleNotFoundError) as e:
+        warning = (
+            f"Could not load cases.yaml (missing dependency: {e.name}). Showing only run cases."
+        )
+
+    return SpecifiedCasesResult(cases=specified, warning=warning)
+
+
+@dataclass
+class CleanResult:
+    """Result of cleaning the index."""
+
+    stale_entries: list[tuple[str, str]]  # (short_id, path)
+    pruned_entries: list[tuple[str, int]]  # (short_id, num_removed)
+    cleaned_index: dict[str, dict[str, Any]]
+    is_clean: bool
+
+
+def clean_index(project_root: Path | None = None) -> CleanResult:
+    """Analyze index and prepare cleaned version.
+
+    Does not save the index — caller decides whether to apply.
+
+    Args:
+        project_root: Project root directory. Defaults to current working directory.
+
+    Returns:
+        CleanResult with stale/pruned entries and the cleaned index.
+    """
+    root = project_root or Path.cwd()
+    index = load_case_index(root)
+
+    stale_entries: list[tuple[str, str]] = []
+    pruned_entries: list[tuple[str, int]] = []
+    cleaned_index: dict[str, dict[str, Any]] = {}
+
+    for case_id, entry in index.items():
+        path = entry["path"]
+        all_paths = entry.get("all_paths", [path])
+        existing_paths = [p for p in all_paths if Path(p).exists()]
+
+        short_id = case_id[:8]
+        if not existing_paths:
+            stale_entries.append((short_id, path))
+        else:
+            cleaned_entry = {
+                "path": existing_paths[0],
+                "handler": entry.get("handler", ""),
+                "all_paths": existing_paths,
+            }
+            if len(existing_paths) < len(all_paths):
+                pruned_entries.append((short_id, len(all_paths) - len(existing_paths)))
+            cleaned_index[case_id] = cleaned_entry
+
+    is_clean = not stale_entries and cleaned_index == index
+
+    return CleanResult(
+        stale_entries=stale_entries,
+        pruned_entries=pruned_entries,
+        cleaned_index=cleaned_index,
+        is_clean=is_clean,
+    )

--- a/src/lembas/param.py
+++ b/src/lembas/param.py
@@ -31,6 +31,9 @@ class InputParameter:
         max: The maximum value for the parameter (if it is a float).
         control: Set as True to indicate a runtime control parameter.
             These parameters will be excluded from the `case.inputs` dictionary.
+        path_format: Format specification for rendering the value in directory paths.
+            For floats, defaults to ".6g" (strips trailing zeros). For other types, uses str().
+        short_name: Optional short alias for use in directory paths instead of the full parameter name.
 
     """
 
@@ -44,6 +47,8 @@ class InputParameter:
         min: float | None = None,
         max: float | None = None,
         control: bool = False,
+        path_format: str | None = None,
+        short_name: str | None = None,
     ):
         if type is not None:
             self._type = type
@@ -58,6 +63,8 @@ class InputParameter:
         self._min_value = min
         self._max_value = max
         self._control = control
+        self._path_format = path_format
+        self._short_name = short_name
 
     def __set_name__(self, owner: type[Case], name: str) -> None:
         self._name = name
@@ -101,3 +108,22 @@ class InputParameter:
     def include_in_inputs_dict(self) -> bool:
         """If True, include the parameter in the `case.inputs` dictionary."""
         return not self._control
+
+    @property
+    def path_name(self) -> str:
+        """Name to use in directory paths.
+
+        Returns short_name if set, otherwise the full parameter name.
+        """
+        return self._short_name or self._name
+
+    def format_for_path(self, value: Any) -> str:
+        """Format a value for use in directory paths.
+
+        Uses path_format if set, otherwise defaults to ".6g" for floats and str() for other types.
+        """
+        if self._path_format is not None:
+            return format(value, self._path_format)
+        if isinstance(value, float):
+            return format(value, ".6g")
+        return str(value)

--- a/tests/test_case_directory.py
+++ b/tests/test_case_directory.py
@@ -1,0 +1,378 @@
+"""Tests for case directory convention: case.id, case_dir, index file handling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import toml
+
+from lembas import Case
+from lembas import InputParameter
+from lembas.index import compute_case_id
+from lembas.index import get_case_dir_from_index
+from lembas.index import load_case_index
+from lembas.index import reindex_cases
+from lembas.index import save_case_index
+from lembas.index import update_case_index
+
+
+class SimpleCase(Case):
+    """A simple case with two parameters."""
+
+    alpha = InputParameter(type=float)
+    beta = InputParameter(type=int)
+
+
+class CaseWithShortNames(Case):
+    """A case with short names for directory paths."""
+
+    froude_number = InputParameter(type=float, short_name="Fr")
+    angle_of_attack = InputParameter(type=float, short_name="AOA")
+
+
+class CaseWithPathFormat(Case):
+    """A case with custom path formatting."""
+
+    value = InputParameter(type=float, path_format=".2f")
+    count = InputParameter(type=int, path_format="03d")
+
+
+class CaseWithManyParams(Case):
+    """A case with more than 3 parameters to test nesting depth limit."""
+
+    param_a = InputParameter(type=float)
+    param_b = InputParameter(type=float)
+    param_c = InputParameter(type=float)
+    param_d = InputParameter(type=float)
+    param_e = InputParameter(type=float)
+
+
+class CaseWithControl(Case):
+    """A case with a control parameter (excluded from inputs)."""
+
+    value = InputParameter(type=float)
+    debug = InputParameter(default=False, control=True)
+
+
+class TestInputParameterPathFormatting:
+    """Tests for InputParameter path_format and short_name."""
+
+    def test_path_name_uses_short_name(self) -> None:
+        param = InputParameter(type=float, short_name="Fr")
+        param._name = "froude_number"
+        assert param.path_name == "Fr"
+
+    def test_path_name_uses_full_name_when_no_short_name(self) -> None:
+        param = InputParameter(type=float)
+        param._name = "froude_number"
+        assert param.path_name == "froude_number"
+
+    def test_format_for_path_uses_custom_format(self) -> None:
+        param = InputParameter(type=float, path_format=".2f")
+        param._name = "value"
+        assert param.format_for_path(3.14159) == "3.14"
+
+    def test_format_for_path_default_float_uses_6g(self) -> None:
+        param = InputParameter(type=float)
+        param._name = "value"
+        assert param.format_for_path(3.14159265) == "3.14159"
+        assert param.format_for_path(0.5) == "0.5"
+        assert param.format_for_path(1000000.0) == "1e+06"
+
+    def test_format_for_path_int_uses_str(self) -> None:
+        param = InputParameter(type=int)
+        param._name = "count"
+        assert param.format_for_path(42) == "42"
+
+    def test_format_for_path_string_uses_str(self) -> None:
+        param = InputParameter(type=str)
+        param._name = "name"
+        assert param.format_for_path("hello") == "hello"
+
+    def test_format_for_path_int_with_custom_format(self) -> None:
+        param = InputParameter(type=int, path_format="05d")
+        param._name = "count"
+        assert param.format_for_path(42) == "00042"
+
+
+class TestCaseId:
+    """Tests for case.id generation."""
+
+    def test_id_is_full_sha256(self) -> None:
+        case = SimpleCase(alpha=1.0, beta=2)
+        assert len(case.id) == 64
+        assert all(c in "0123456789abcdef" for c in case.id)
+
+    def test_short_id_is_8_chars(self) -> None:
+        case = SimpleCase(alpha=1.0, beta=2)
+        assert len(case.short_id) == 8
+        assert case.short_id == case.id[:8]
+
+    def test_id_is_deterministic(self) -> None:
+        case1 = SimpleCase(alpha=1.0, beta=2)
+        case2 = SimpleCase(alpha=1.0, beta=2)
+        assert case1.id == case2.id
+
+    def test_id_differs_for_different_inputs(self) -> None:
+        case1 = SimpleCase(alpha=1.0, beta=2)
+        case2 = SimpleCase(alpha=1.0, beta=3)
+        assert case1.id != case2.id
+
+    def test_id_is_alphabetically_sorted(self) -> None:
+        # Create cases with params in different order but same values
+        case1 = SimpleCase(alpha=1.0, beta=2)
+        case2 = SimpleCase(beta=2, alpha=1.0)
+        # Both should produce the same id because inputs are sorted alphabetically
+        assert case1.id == case2.id
+
+    def test_id_excludes_control_params(self) -> None:
+        case1 = CaseWithControl(value=1.0)
+        case2 = CaseWithControl(value=1.0, debug=True)
+        # Control params are excluded from inputs, so id should be the same
+        assert case1.id == case2.id
+
+
+class TestCaseDir:
+    """Tests for default case_dir generation."""
+
+    def test_case_dir_nests_by_declaration_order(self) -> None:
+        case = SimpleCase(alpha=1.5, beta=10)
+        # Should use declaration order: alpha, beta
+        expected_suffix = Path("cases") / "alpha=1.5" / "beta=10"
+        assert case.case_dir.parts[-3:] == expected_suffix.parts
+
+    def test_case_dir_uses_short_names(self) -> None:
+        case = CaseWithShortNames(froude_number=0.5, angle_of_attack=5.0)
+        expected_suffix = Path("cases") / "Fr=0.5" / "AOA=5"
+        assert case.case_dir.parts[-3:] == expected_suffix.parts
+
+    def test_case_dir_uses_path_format(self) -> None:
+        case = CaseWithPathFormat(value=3.14159, count=7)
+        expected_suffix = Path("cases") / "value=3.14" / "count=007"
+        assert case.case_dir.parts[-3:] == expected_suffix.parts
+
+    def test_case_dir_limits_nesting_to_3_params(self) -> None:
+        case = CaseWithManyParams(param_a=1.0, param_b=2.0, param_c=3.0, param_d=4.0, param_e=5.0)
+        # Only first 3 params should be in path
+        expected_suffix = Path("cases") / "param_a=1" / "param_b=2" / "param_c=3"
+        assert case.case_dir.parts[-4:] == expected_suffix.parts
+
+    def test_case_dir_excludes_control_params(self) -> None:
+        case = CaseWithControl(value=1.5, debug=True)
+        # Only non-control param should be in path
+        expected_suffix = Path("cases") / "value=1.5"
+        assert case.case_dir.parts[-2:] == expected_suffix.parts
+
+    def test_case_dir_is_absolute(self) -> None:
+        case = SimpleCase(alpha=1.0, beta=2)
+        assert case.case_dir.is_absolute()
+
+    def test_relative_case_dir_is_relative(self) -> None:
+        case = SimpleCase(alpha=1.0, beta=2)
+        # Default case_dir is under cwd, so relative_case_dir should be relative
+        assert not case.relative_case_dir.is_absolute()
+        assert case.relative_case_dir.parts[0] == "cases"
+
+
+class TestCaseIndex:
+    """Tests for case index file handling."""
+
+    def test_load_empty_index(self, tmp_path: Path) -> None:
+        index = load_case_index(tmp_path)
+        assert index == {}
+
+    def test_save_and_load_index(self, tmp_path: Path) -> None:
+        index = {
+            "abc123": {
+                "path": "cases/alpha=1/beta=2",
+                "handler": "Case1",
+                "all_paths": ["cases/alpha=1/beta=2"],
+            },
+            "def456": {
+                "path": "cases/alpha=3/beta=4",
+                "handler": "Case2",
+                "all_paths": ["cases/alpha=3/beta=4"],
+            },
+        }
+        save_case_index(index, tmp_path)
+
+        loaded = load_case_index(tmp_path)
+        assert loaded == index
+
+    def test_save_creates_lembas_dir(self, tmp_path: Path) -> None:
+        index = {"abc123": {"path": "cases/test", "handler": "Case", "all_paths": ["cases/test"]}}
+        save_case_index(index, tmp_path)
+        assert (tmp_path / ".lembas").exists()
+        assert (tmp_path / ".lembas" / "cases.json").exists()
+
+    def test_update_case_index(self, tmp_path: Path) -> None:
+        # Start with empty index
+        update_case_index("abc123", tmp_path / "cases" / "test1", "Handler1", tmp_path)
+        update_case_index("def456", tmp_path / "cases" / "test2", "Handler2", tmp_path)
+
+        index = load_case_index(tmp_path)
+        assert index["abc123"]["path"] == "cases/test1"
+        assert index["abc123"]["handler"] == "Handler1"
+        assert index["def456"]["path"] == "cases/test2"
+        assert index["def456"]["handler"] == "Handler2"
+
+    def test_get_case_dir_from_index_found(self, tmp_path: Path) -> None:
+        # Create a case directory
+        case_dir = tmp_path / "cases" / "test"
+        case_dir.mkdir(parents=True)
+
+        save_case_index(
+            {"abc123": {"path": "cases/test", "handler": "Case", "all_paths": ["cases/test"]}},
+            tmp_path,
+        )
+
+        result = get_case_dir_from_index("abc123", tmp_path)
+        assert result == case_dir
+
+    def test_get_case_dir_from_index_not_found(self, tmp_path: Path) -> None:
+        result = get_case_dir_from_index("nonexistent", tmp_path)
+        assert result is None
+
+    def test_get_case_dir_from_index_missing_directory(self, tmp_path: Path) -> None:
+        # Index points to non-existent directory
+        save_case_index(
+            {
+                "abc123": {
+                    "path": "cases/missing",
+                    "handler": "Case",
+                    "all_paths": ["cases/missing"],
+                }
+            },
+            tmp_path,
+        )
+
+        result = get_case_dir_from_index("abc123", tmp_path)
+        assert result is None
+
+
+class TestComputeCaseId:
+    """Tests for compute_case_id function."""
+
+    def test_compute_case_id_matches_case_property(self) -> None:
+        case = SimpleCase(alpha=1.0, beta=2)
+        computed = compute_case_id(case.fully_resolved_name, case.inputs)
+        assert computed == case.id
+
+    def test_compute_case_id_alphabetical_order(self) -> None:
+        # Order of keys in inputs dict shouldn't matter
+        id1 = compute_case_id("test.Case", {"alpha": 1.0, "beta": 2})
+        id2 = compute_case_id("test.Case", {"beta": 2, "alpha": 1.0})
+        assert id1 == id2
+
+
+class TestReindexCases:
+    """Tests for reindex_cases function."""
+
+    def test_reindex_empty_directory(self, tmp_path: Path) -> None:
+        index = reindex_cases(tmp_path / "cases", tmp_path)
+        assert index == {}
+
+    def test_reindex_finds_case_toml_files(self, tmp_path: Path) -> None:
+        # Create a case directory with case.toml
+        case_dir = tmp_path / "cases" / "alpha=1" / "beta=2"
+        lembas_dir = case_dir / "lembas"
+        lembas_dir.mkdir(parents=True)
+
+        case_toml = lembas_dir / "case.toml"
+        case_toml.write_text(
+            toml.dumps(
+                {
+                    "lembas": {
+                        "case-handler": "test.SimpleCase",
+                        "inputs": {"alpha": 1.0, "beta": 2},
+                    }
+                }
+            )
+        )
+
+        index = reindex_cases(tmp_path / "cases", tmp_path)
+
+        expected_id = compute_case_id("test.SimpleCase", {"alpha": 1.0, "beta": 2})
+        assert expected_id in index
+        assert index[expected_id]["path"] == "cases/alpha=1/beta=2"
+        assert index[expected_id]["handler"] == "SimpleCase"
+
+    def test_reindex_multiple_cases(self, tmp_path: Path) -> None:
+        # Create multiple case directories
+        for i in range(3):
+            case_dir = tmp_path / "cases" / f"value={i}"
+            lembas_dir = case_dir / "lembas"
+            lembas_dir.mkdir(parents=True)
+
+            case_toml = lembas_dir / "case.toml"
+            case_toml.write_text(
+                toml.dumps(
+                    {
+                        "lembas": {
+                            "case-handler": "test.Case",
+                            "inputs": {"value": i},
+                        }
+                    }
+                )
+            )
+
+        index = reindex_cases(tmp_path / "cases", tmp_path)
+        assert len(index) == 3
+
+    def test_reindex_skips_invalid_toml(self, tmp_path: Path) -> None:
+        # Create a case with invalid toml
+        case_dir = tmp_path / "cases" / "bad"
+        lembas_dir = case_dir / "lembas"
+        lembas_dir.mkdir(parents=True)
+
+        case_toml = lembas_dir / "case.toml"
+        case_toml.write_text("not valid toml [[[")
+
+        # Create a valid case too
+        good_dir = tmp_path / "cases" / "good"
+        good_lembas = good_dir / "lembas"
+        good_lembas.mkdir(parents=True)
+        good_toml = good_lembas / "case.toml"
+        good_toml.write_text(
+            toml.dumps(
+                {
+                    "lembas": {
+                        "case-handler": "test.Case",
+                        "inputs": {"value": 1},
+                    }
+                }
+            )
+        )
+
+        index = reindex_cases(tmp_path / "cases", tmp_path)
+        # Should only have the good case
+        assert len(index) == 1
+
+    def test_reindex_saves_index_file(self, tmp_path: Path) -> None:
+        # Create a case
+        case_dir = tmp_path / "cases" / "test"
+        lembas_dir = case_dir / "lembas"
+        lembas_dir.mkdir(parents=True)
+
+        case_toml = lembas_dir / "case.toml"
+        case_toml.write_text(
+            toml.dumps(
+                {
+                    "lembas": {
+                        "case-handler": "test.Case",
+                        "inputs": {"value": 1},
+                    }
+                }
+            )
+        )
+
+        reindex_cases(tmp_path / "cases", tmp_path)
+
+        # Index file should be created
+        index_file = tmp_path / ".lembas" / "cases.json"
+        assert index_file.exists()
+
+        # And contain the case
+        saved_index = json.loads(index_file.read_text())
+        assert len(saved_index) == 1

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -52,17 +52,18 @@ class MyCase(Case):
 
 @pytest.fixture()
 def case() -> MyCase:
-    return MyCase(my_param=3.0)
+    return MyCase(my_param=3.0, required_param=1.0)
 
 
 def test_case_parameter_default(case: MyCase) -> None:
     assert case.param_with_default == pytest.approx(10.0)
 
 
-def test_case_parameter_required_raises_exception(case: MyCase) -> None:
+def test_case_parameter_required_raises_exception() -> None:
     """A parameter with no default that is not set raises an exception when accessed."""
+    case_without_required = MyCase(my_param=3.0)
     with pytest.raises(AttributeError):
-        _ = case.required_param
+        _ = case_without_required.required_param
 
 
 def test_case_parameter_type_required() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,3 +201,156 @@ def test_run_with_task_runs_pixi_task(invoke_cli: CLIInvoker, run_path: Path) ->
     # Task doesn't exist, so we get an error
     assert result.exit_code == 1
     assert "Unknown task: nonexistent" in result.stdout
+
+
+class TestCasesListCommand:
+    """Tests for `lembas cases list` command."""
+
+    def test_cases_list_empty(self, invoke_cli: CLIInvoker) -> None:
+        """With no index file, shows no cases message."""
+        result = invoke_cli("cases", "list")
+        assert result.exit_code == 0
+        assert "No cases found" in result.stdout
+
+    def test_cases_list_with_index(self, invoke_cli: CLIInvoker, run_path: Path) -> None:
+        """With an index file, shows cases in a table."""
+        import json
+
+        # Create index file
+        lembas_dir = run_path / ".lembas"
+        lembas_dir.mkdir()
+        index_file = lembas_dir / "cases.json"
+        # Full 64-char case IDs
+        case_id_1 = "abc12345" + "0" * 56
+        case_id_2 = "def67890" + "0" * 56
+        index_file.write_text(
+            json.dumps(
+                {
+                    case_id_1: "cases/alpha=1/beta=2",
+                    case_id_2: "cases/alpha=3/beta=4",
+                }
+            )
+        )
+
+        result = invoke_cli("cases", "list")
+        assert result.exit_code == 0
+        # Display shows short IDs (first 8 chars)
+        assert "abc12345" in result.stdout
+        assert "def67890" in result.stdout
+        assert "cases/alpha=1/beta=2" in result.stdout
+
+    def test_cases_list_shows_missing_status(self, invoke_cli: CLIInvoker, run_path: Path) -> None:
+        """Directories that don't exist are marked as missing."""
+        import json
+
+        lembas_dir = run_path / ".lembas"
+        lembas_dir.mkdir()
+        index_file = lembas_dir / "cases.json"
+        case_id = "abc12345" + "0" * 56
+        index_file.write_text(json.dumps({case_id: "cases/nonexistent"}))
+
+        result = invoke_cli("cases", "list")
+        assert result.exit_code == 0
+        assert "missing" in result.stdout
+
+    def test_cases_list_shows_complete_status(self, invoke_cli: CLIInvoker, run_path: Path) -> None:
+        """Directories that exist are marked as complete."""
+        import json
+
+        import toml
+
+        # Create the case directory with a case.toml
+        case_dir = run_path / "cases" / "test"
+        lembas_case_dir = case_dir / "lembas"
+        lembas_case_dir.mkdir(parents=True)
+        case_toml = lembas_case_dir / "case.toml"
+        case_toml.write_text(
+            toml.dumps({"lembas": {"case-handler": "test.Case", "inputs": {"value": 1}}})
+        )
+
+        # Create index with rich format (full 64-char case ID)
+        lembas_dir = run_path / ".lembas"
+        lembas_dir.mkdir()
+        index_file = lembas_dir / "cases.json"
+        case_id = "abc12345" + "0" * 56
+        index_file.write_text(
+            json.dumps(
+                {
+                    case_id: {
+                        "path": "cases/test",
+                        "handler": "Case",
+                        "all_paths": ["cases/test"],
+                    }
+                }
+            )
+        )
+
+        result = invoke_cli("cases", "list")
+        assert result.exit_code == 0
+        assert "complete" in result.stdout
+
+    def test_cases_list_auto_reindexes(self, invoke_cli: CLIInvoker, run_path: Path) -> None:
+        """When index is empty but case.toml files exist, auto-reindex."""
+        import toml
+
+        # Create a case directory with case.toml but NO index file
+        case_dir = run_path / "cases" / "value=1"
+        lembas_dir = case_dir / "lembas"
+        lembas_dir.mkdir(parents=True)
+
+        case_toml = lembas_dir / "case.toml"
+        case_toml.write_text(
+            toml.dumps(
+                {
+                    "lembas": {
+                        "case-handler": "test.Case",
+                        "inputs": {"value": 1},
+                    }
+                }
+            )
+        )
+
+        # No .lembas/cases.json exists
+        result = invoke_cli("cases", "list")
+        assert result.exit_code == 0
+        # Should find the case via auto-reindex
+        assert "cases/value=1" in result.stdout
+
+
+class TestCasesReindexCommand:
+    """Tests for `lembas cases reindex` command."""
+
+    def test_cases_reindex_empty(self, invoke_cli: CLIInvoker) -> None:
+        """With no cases, reindex shows 0 cases."""
+        result = invoke_cli("cases", "reindex")
+        assert result.exit_code == 0
+        assert "Found 0 cases" in result.stdout
+
+    def test_cases_reindex_finds_cases(self, invoke_cli: CLIInvoker, run_path: Path) -> None:
+        """Reindex finds case.toml files and rebuilds index."""
+        import toml
+
+        # Create a case directory with case.toml
+        case_dir = run_path / "cases" / "value=1"
+        lembas_dir = case_dir / "lembas"
+        lembas_dir.mkdir(parents=True)
+
+        case_toml = lembas_dir / "case.toml"
+        case_toml.write_text(
+            toml.dumps(
+                {
+                    "lembas": {
+                        "case-handler": "test.Case",
+                        "inputs": {"value": 1},
+                    }
+                }
+            )
+        )
+
+        result = invoke_cli("cases", "reindex")
+        assert result.exit_code == 0
+        assert "Found 1 cases" in result.stdout
+
+        # Verify index file was created
+        index_file = run_path / ".lembas" / "cases.json"
+        assert index_file.exists()


### PR DESCRIPTION
## Summary

- Implements sensible default for case directories that nests first 3 parameters by declaration order
- Adds `path_format` and `short_name` fields to `InputParameter` for path customization
- Adds content-addressed `case_id` property to `Case` (SHA-256, 16 hex chars)
- Adds `.lembas/cases.json` index as cache with `lembas/case.toml` as source of truth
- Adds `lembas cases list` and `lembas cases reindex` CLI commands
- Documents design decisions in ADR

## Directory structure example

```
cases/
  froude_num=0.5/
    angle_of_attack=5.0/
    angle_of_attack=7.5/
  froude_num=1.0/
    angle_of_attack=5.0/
```

With `short_name` customization:
```
cases/
  Fr=0.50/
    AOA=5.00/
```

## Test plan

- [x] All existing tests pass
- [x] New tests for InputParameter formatting, case_id generation, case_dir nesting
- [x] New tests for index file load/save/reindex
- [x] New tests for `lembas cases list` and `lembas cases reindex` commands
- [x] Type checking passes
- [x] Linting passes