### PR TITLE
feat: Add CaseNotRunError for result access before run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ venv.bak/
 
 # Version file
 /src/lembas/_version.py
+.lembas/

--- a/src/lembas/__init__.py
+++ b/src/lembas/__init__.py
@@ -1,6 +1,7 @@
 from lembas._version import __version__
 from lembas.case import Case
 from lembas.case import CaseList
+from lembas.case import CaseNotRunError
 from lembas.case import step
 from lembas.param import InputParameter
 from lembas.plugins import load_plugins_from_file
@@ -11,6 +12,7 @@ from lembas.study import load_cases
 __all__ = [
     "Case",
     "CaseList",
+    "CaseNotRunError",
     "InputParameter",
     "load_cases",
     "load_local_plugins",

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -23,7 +23,13 @@ from lembas.logging import logger
 from lembas.param import InputParameter
 from lembas.results import Results
 
-__all__ = ["Case", "CaseList", "step"]
+__all__ = ["Case", "CaseList", "CaseNotRunError", "step"]
+
+
+class CaseNotRunError(Exception):
+    """Raised when attempting to access results before the case has been run."""
+
+    pass
 
 
 LEMBAS_CASE_TOML_FILENAME = Path("lembas", "case.toml")
@@ -144,6 +150,14 @@ class Case:
     def short_id(self) -> str:
         """Short form of id for display (first 8 characters)."""
         return self.id[:8]
+
+    @property
+    def has_run(self) -> bool:
+        """Whether this case has been run.
+
+        Checks for the existence of the lembas/case.toml file in the case directory.
+        """
+        return (self.case_dir / LEMBAS_CASE_TOML_FILENAME).exists()
 
     @classmethod
     def _get_input_parameters_by_declaration_order(cls) -> list[InputParameter]:

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -9,6 +9,7 @@ import types
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
+from datetime import UTC
 from functools import WRAPPER_ASSIGNMENTS
 from functools import cached_property
 from pathlib import Path
@@ -33,6 +34,7 @@ class CaseNotRunError(Exception):
 
 
 LEMBAS_CASE_TOML_FILENAME = Path("lembas", "case.toml")
+LEMBAS_STATUS_FILENAME = Path("lembas", "status.json")
 
 TCase = TypeVar("TCase", bound="Case")
 RawCaseStepMethod = Callable[[TCase], None]
@@ -153,11 +155,37 @@ class Case:
 
     @property
     def has_run(self) -> bool:
-        """Whether this case has been run.
+        """Whether all steps have completed for this case.
 
-        Checks for the existence of the lembas/case.toml file in the case directory.
+        Checks that all declared steps have entries in the status file.
         """
-        return (self.case_dir / LEMBAS_CASE_TOML_FILENAME).exists()
+        status = self._load_status()
+        if status is None:
+            return False
+        declared_steps = set(self._steps.keys())
+        completed_steps = set(status.get("steps", {}).keys())
+        return declared_steps <= completed_steps
+
+    def _load_status(self) -> dict[str, Any] | None:
+        """Load status from lembas/status.json if it exists."""
+        status_file = self.case_dir / LEMBAS_STATUS_FILENAME
+        if not status_file.exists():
+            return None
+        return json.loads(status_file.read_text())
+
+    def _save_status(self, status: dict[str, Any]) -> None:
+        """Save status to lembas/status.json."""
+        status_file = self.case_dir / LEMBAS_STATUS_FILENAME
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        status_file.write_text(json.dumps(status, indent=2))
+
+    def _mark_step_complete(self, step_name: str) -> None:
+        """Record that a step has completed."""
+        from datetime import datetime
+
+        status = self._load_status() or {"steps": {}}
+        status["steps"][step_name] = {"completed_at": datetime.now(UTC).isoformat()}
+        self._save_status(status)
 
     @classmethod
     def _get_input_parameters_by_declaration_order(cls) -> list[InputParameter]:
@@ -238,11 +266,25 @@ class Case:
         decorated with ``@step``.
 
         """
+        from datetime import datetime
+
         self._check_index_sync()
         self.log("Running %s", self)
         self._write_lembas_file()
+
+        # Initialize status
+        status = self._load_status() or {"steps": {}}
+        status["started_at"] = datetime.now(UTC).isoformat()
+        self._save_status(status)
+
         for step_method in self._sorted_steps:
             step_method(self)
+            self._mark_step_complete(step_method.name)
+
+        # Mark overall completion
+        status = self._load_status() or {}
+        status["completed_at"] = datetime.now(UTC).isoformat()
+        self._save_status(status)
 
     def _check_index_sync(self) -> None:
         """Warn if the indexed path for this id differs from computed case_dir."""

--- a/src/lembas/index.py
+++ b/src/lembas/index.py
@@ -31,6 +31,34 @@ __all__ = [
 LEMBAS_DIR = Path(".lembas")
 CASES_INDEX_FILE = LEMBAS_DIR / "cases.json"
 CASE_TOML_PATH = Path("lembas") / "case.toml"
+STATUS_FILE_PATH = Path("lembas") / "status.json"
+
+
+def _get_case_status(case_dir: Path) -> CaseStatus:
+    """Determine case status from filesystem.
+
+    A case is COMPLETE if status.json exists and has completed_at set.
+    A case is PENDING if it has case.toml or status.json but isn't complete.
+    A case is MISSING if the directory doesn't exist.
+    """
+    if not case_dir.exists():
+        return CaseStatus.MISSING
+
+    status_file = case_dir / STATUS_FILE_PATH
+    if status_file.exists():
+        try:
+            status = json.loads(status_file.read_text())
+            if status.get("completed_at"):
+                return CaseStatus.COMPLETE
+        except (json.JSONDecodeError, OSError):
+            pass
+        return CaseStatus.PENDING
+
+    case_toml = case_dir / CASE_TOML_PATH
+    if case_toml.exists():
+        return CaseStatus.PENDING
+
+    return CaseStatus.MISSING
 
 
 class CaseStatus(Enum):
@@ -266,7 +294,6 @@ def gather_case_info(
             path = entry["path"]
             handler = entry.get("handler", "")
             all_paths = entry.get("all_paths", [path])
-            path_exists = Path(path).exists()
 
             # Check for duplicates
             notes = ""
@@ -280,7 +307,7 @@ def gather_case_info(
                 if path != specified_path:
                     notes = f"expected: {specified_path}"
 
-            status = CaseStatus.COMPLETE if path_exists else CaseStatus.MISSING
+            status = _get_case_status(Path(path))
             if not handler:
                 handler = "-"
         else:

--- a/src/lembas/results.py
+++ b/src/lembas/results.py
@@ -35,6 +35,15 @@ class Results:
         return parent
 
     def __getattr__(self, item: str) -> Any:
+        # Check if the case has been run before allowing result access
+        if not self.parent.has_run:
+            from lembas.case import CaseNotRunError
+
+            raise CaseNotRunError(
+                f"Cannot access result '{item}' because the case has not been run. "
+                f"Call case.run() first."
+            )
+
         # During attribute access, we search the class for methods to which have been
         # attached a "_provides_results" tuple. If we find that, and the requested
         # result is in that tuple, we call the method (once) and cache the results in

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,7 +254,7 @@ class TestCasesListCommand:
         assert "missing" in result.stdout
 
     def test_cases_list_shows_complete_status(self, invoke_cli: CLIInvoker, run_path: Path) -> None:
-        """Directories that exist are marked as complete."""
+        """Cases with completed status.json are marked as complete."""
         import json
 
         import toml
@@ -267,6 +267,10 @@ class TestCasesListCommand:
         case_toml.write_text(
             toml.dumps({"lembas": {"case-handler": "test.Case", "inputs": {"value": 1}}})
         )
+
+        # Create status.json with completed_at to mark as complete
+        status_file = lembas_case_dir / "status.json"
+        status_file.write_text(json.dumps({"completed_at": "2026-07-17T12:00:00Z", "steps": {}}))
 
         # Create index with rich format (full 64-char case ID)
         lembas_dir = run_path / ".lembas"

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,6 +1,9 @@
+import os
+
 import pytest
 
 from lembas import Case
+from lembas import CaseNotRunError
 from lembas import result
 
 
@@ -23,36 +26,63 @@ class MyCase(Case):
 
 
 @pytest.fixture()
-def case() -> MyCase:
-    return MyCase()
+def case(tmp_path: pytest.TempPathFactory) -> MyCase:  # type: ignore[misc]
+    # Change to temp directory so case_dir is writable
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    c = MyCase()
+    yield c
+    os.chdir(old_cwd)
+
+
+@pytest.fixture()
+def run_case(case: MyCase) -> MyCase:
+    """Fixture that provides a case that has been run."""
+    case.run()
+    return case
 
 
 def test_case_results_parent(case: MyCase) -> None:
     assert case.results.parent is case
 
 
-def test_case_results_get_attr_no_args(case: MyCase) -> None:
-    assert case.results.some_result == "some_result_value"
+def test_case_results_raises_before_run(case: MyCase) -> None:
+    """Accessing results before run() raises CaseNotRunError."""
+    with pytest.raises(CaseNotRunError) as exc_info:
+        _ = case.results.some_result
+    assert "has not been run" in str(exc_info.value)
+    assert "some_result" in str(exc_info.value)
 
 
-def test_cas_results_get_attr_with_args_single(case: MyCase) -> None:
-    assert case.results.single_result == "single_result_value"
+def test_case_results_get_attr_no_args(run_case: MyCase) -> None:
+    assert run_case.results.some_result == "some_result_value"
 
 
-def test_case_results_get_attr_multiple(case: MyCase) -> None:
-    assert case.results.first_result == "first_result_value"
-    assert case.results.get("second_result") == "second_result_value"
+def test_cas_results_get_attr_with_args_single(run_case: MyCase) -> None:
+    assert run_case.results.single_result == "single_result_value"
 
 
-def test_case_results_incorrect_number_of_results(case: MyCase) -> None:
+def test_case_results_get_attr_multiple(run_case: MyCase) -> None:
+    assert run_case.results.first_result == "first_result_value"
+    assert run_case.results.get("second_result") == "second_result_value"
+
+
+def test_case_results_incorrect_number_of_results(run_case: MyCase) -> None:
     with pytest.raises(ValueError):
-        _ = case.results.first_result_expected
+        _ = run_case.results.first_result_expected
 
 
-def test_case_results_undefined(case: MyCase) -> None:
+def test_case_results_undefined(run_case: MyCase) -> None:
     with pytest.raises(AttributeError):
-        _ = case.results.nonexistent_result
+        _ = run_case.results.nonexistent_result
 
 
 def test_case_results_method_provides_results(case: MyCase) -> None:
     assert MyCase.some_result._provides_results == ("some_result",)  # type: ignore
+
+
+def test_case_has_run_property(case: MyCase) -> None:
+    """has_run is False before run(), True after."""
+    assert case.has_run is False
+    case.run()
+    assert case.has_run is True

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -26,7 +27,7 @@ class MyCase(Case):
 
 
 @pytest.fixture()
-def case(tmp_path: pytest.TempPathFactory) -> MyCase:  # type: ignore[misc]
+def case(tmp_path: Path) -> MyCase:  # type: ignore[misc]
     # Change to temp directory so case_dir is writable
     old_cwd = os.getcwd()
     os.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Resolves the `@result` vs `@step` boundary question: results are pure reads of state set by steps. Accessing a result before running the case raises `CaseNotRunError`.

## Changes

### Step completion tracking (`status.json`)

Cases now track step completion in `lembas/status.json`:

```json
{
  "started_at": "2026-07-17T22:30:00Z",
  "completed_at": "2026-07-17T22:35:00Z",
  "steps": {
    "prepare": {"completed_at": "2026-07-17T22:31:00Z"},
    "generate_mesh": {"completed_at": "2026-07-17T22:33:00Z"}
  }
}
```

### `has_run` property

A case is considered "has run" when all declared `@step` methods have entries in `status.json`. This correctly handles:
- Cases that crash mid-run (partial steps completed)
- Re-runs that skip completed steps
- Foundation for resume functionality

### `CaseNotRunError`

Accessing `case.results.some_result` before `run()` raises:
```
CaseNotRunError: Cannot access result 'some_result' because the case has not been run. Call case.run() first.
```

### Index status detection

`lembas cases list` now shows:
- **complete**: `status.json` exists with `completed_at` set
- **pending**: `case.toml` or `status.json` exists but not complete  
- **missing**: directory doesn't exist

## Test plan

- [x] `pixi run test` passes
- [x] `pixi run typecheck` passes
- [x] `pixi run lint` passes
- [x] New tests for `CaseNotRunError` and `has_run` property
- [x] Updated CLI test for complete status detection