### PR TITLE
ci: Use trusted publishing for PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,20 +50,14 @@ jobs:
     name: Publish wheel to PyPI
     if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: Setup Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
     - name: Download the build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: wheel-${{ github.sha }}
         path: ./dist
-    - name: Install build dependencies
-      run: pip install twine
-    - name: Upload to PyPI with twine
-      run: python -m twine upload ./dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
## Summary

Switch from token-based authentication to OIDC trusted publishing for PyPI uploads.

## Changes

- Use `pypa/gh-action-pypi-publish` action instead of twine
- Add `id-token: write` permission for OIDC
- Add `environment: pypi` to match trusted publisher config
- Remove `PYPI_TOKEN` secret usage (can be deleted after merge)

## Prerequisites

Trusted publisher configured on PyPI with:
- Owner: `lembas-project`
- Repository: `lembas-core`
- Workflow: `publish.yml`
- Environment: `pypi`