### PR TITLE
ci: Enable verbose mode for PyPI publish debugging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,3 +61,5 @@ jobs:
         path: ./dist
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        verbose: true


### PR DESCRIPTION
Debug the 400 Bad Request error from PyPI