### PR TITLE
ci: Disable PyPI attestations for reusable workflow compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,3 +63,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         verbose: true
+        attestations: false


### PR DESCRIPTION
## Summary

Disable attestations when publishing to PyPI. Attestations embed the caller workflow (`test.yml`) in Sigstore certificates, but PyPI's trusted publisher is configured for the called workflow (`publish.yml`), causing a mismatch.

## Context

With reusable workflows:
- OIDC token `job_workflow_ref` = `publish.yml` (used for trusted publisher matching)
- Sigstore attestation certificate embeds `test.yml` (the caller)

This mismatch causes PyPI to reject uploads with attestations enabled.