### PR TITLE
feat: Add in_case_dir context manager to Case base class

### DIFF
--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -5,10 +5,12 @@ import inspect
 import itertools
 import json
 import logging
+import os
 import types
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC
 from functools import WRAPPER_ASSIGNMENTS
 from functools import cached_property
@@ -227,6 +229,16 @@ class Case:
             return self.case_dir.relative_to(Path.cwd())
         except ValueError:
             return self.case_dir
+
+    @contextmanager
+    def in_case_dir(self) -> Iterator[None]:
+        """Context manager to temporarily change to the case directory."""
+        original = os.getcwd()
+        try:
+            os.chdir(self.case_dir)
+            yield
+        finally:
+            os.chdir(original)
 
     @property
     def inputs(self) -> dict[str, Any]:

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -177,6 +178,18 @@ def test_case_relative_case_dir_is_relative(case: MyCase, tmp_path: Path) -> Non
     """If the case_dir is relative to CWD, the relative_case_dir is relative."""
     case.case_dir = Path.cwd() / "some/relative-path"
     assert case.relative_case_dir == Path("some/relative-path")
+
+
+def test_in_case_dir_changes_and_restores_cwd(case: MyCase, tmp_path: Path) -> None:
+    """in_case_dir temporarily changes to case_dir and restores on exit."""
+    case.case_dir = tmp_path / "case"
+    case.case_dir.mkdir(parents=True)
+    original_cwd = os.getcwd()
+
+    with case.in_case_dir():
+        assert os.getcwd() == str(case.case_dir)
+
+    assert os.getcwd() == original_cwd
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Adds `in_case_dir()` context manager to the `Case` base class
- Temporarily changes working directory to `case_dir` and restores on exit
- Reduces boilerplate in case handler implementations that need to run commands in the case directory

## Test plan
- [x] Added unit test verifying directory change and restoration
- [x] All existing tests pass