### PR TITLE
refactor!: Rename internal case directory from lembas to .lembas

### DIFF
--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -35,8 +35,8 @@ class CaseNotRunError(Exception):
     pass
 
 
-LEMBAS_CASE_TOML_FILENAME = Path("lembas", "case.toml")
-LEMBAS_STATUS_FILENAME = Path("lembas", "status.json")
+LEMBAS_CASE_TOML_FILENAME = Path(".lembas", "case.toml")
+LEMBAS_STATUS_FILENAME = Path(".lembas", "status.json")
 
 TCase = TypeVar("TCase", bound="Case")
 RawCaseStepMethod = Callable[[TCase], None]

--- a/src/lembas/index.py
+++ b/src/lembas/index.py
@@ -30,8 +30,8 @@ __all__ = [
 
 LEMBAS_DIR = Path(".lembas")
 CASES_INDEX_FILE = LEMBAS_DIR / "cases.json"
-CASE_TOML_PATH = Path("lembas") / "case.toml"
-STATUS_FILE_PATH = Path("lembas") / "status.json"
+CASE_TOML_PATH = Path(".lembas") / "case.toml"
+STATUS_FILE_PATH = Path(".lembas") / "status.json"
 
 
 def _get_case_status(case_dir: Path) -> CaseStatus:

--- a/tests/test_case_directory.py
+++ b/tests/test_case_directory.py
@@ -276,7 +276,7 @@ class TestReindexCases:
     def test_reindex_finds_case_toml_files(self, tmp_path: Path) -> None:
         # Create a case directory with case.toml
         case_dir = tmp_path / "cases" / "alpha=1" / "beta=2"
-        lembas_dir = case_dir / "lembas"
+        lembas_dir = case_dir / ".lembas"
         lembas_dir.mkdir(parents=True)
 
         case_toml = lembas_dir / "case.toml"
@@ -302,7 +302,7 @@ class TestReindexCases:
         # Create multiple case directories
         for i in range(3):
             case_dir = tmp_path / "cases" / f"value={i}"
-            lembas_dir = case_dir / "lembas"
+            lembas_dir = case_dir / ".lembas"
             lembas_dir.mkdir(parents=True)
 
             case_toml = lembas_dir / "case.toml"
@@ -323,7 +323,7 @@ class TestReindexCases:
     def test_reindex_skips_invalid_toml(self, tmp_path: Path) -> None:
         # Create a case with invalid toml
         case_dir = tmp_path / "cases" / "bad"
-        lembas_dir = case_dir / "lembas"
+        lembas_dir = case_dir / ".lembas"
         lembas_dir.mkdir(parents=True)
 
         case_toml = lembas_dir / "case.toml"
@@ -331,7 +331,7 @@ class TestReindexCases:
 
         # Create a valid case too
         good_dir = tmp_path / "cases" / "good"
-        good_lembas = good_dir / "lembas"
+        good_lembas = good_dir / ".lembas"
         good_lembas.mkdir(parents=True)
         good_toml = good_lembas / "case.toml"
         good_toml.write_text(
@@ -352,7 +352,7 @@ class TestReindexCases:
     def test_reindex_saves_index_file(self, tmp_path: Path) -> None:
         # Create a case
         case_dir = tmp_path / "cases" / "test"
-        lembas_dir = case_dir / "lembas"
+        lembas_dir = case_dir / ".lembas"
         lembas_dir.mkdir(parents=True)
 
         case_toml = lembas_dir / "case.toml"

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -162,8 +162,8 @@ def test_case_lembas_toml(case: MyCase, tmp_path: Path) -> None:
     case.required_param = 4.0
     assert case.case_dir == tmp_path
     case._write_lembas_file()
-    assert (tmp_path / "lembas" / "case.toml").exists()
-    with (tmp_path / "lembas" / "case.toml").open("r") as fp:
+    assert (tmp_path / ".lembas" / "case.toml").exists()
+    with (tmp_path / ".lembas" / "case.toml").open("r") as fp:
         data = toml.load(fp)
     assert data == {"lembas": {"inputs": case.inputs, "case-handler": case.fully_resolved_name}}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,7 +261,7 @@ class TestCasesListCommand:
 
         # Create the case directory with a case.toml
         case_dir = run_path / "cases" / "test"
-        lembas_case_dir = case_dir / "lembas"
+        lembas_case_dir = case_dir / ".lembas"
         lembas_case_dir.mkdir(parents=True)
         case_toml = lembas_case_dir / "case.toml"
         case_toml.write_text(
@@ -299,7 +299,7 @@ class TestCasesListCommand:
 
         # Create a case directory with case.toml but NO index file
         case_dir = run_path / "cases" / "value=1"
-        lembas_dir = case_dir / "lembas"
+        lembas_dir = case_dir / ".lembas"
         lembas_dir.mkdir(parents=True)
 
         case_toml = lembas_dir / "case.toml"
@@ -336,7 +336,7 @@ class TestCasesReindexCommand:
 
         # Create a case directory with case.toml
         case_dir = run_path / "cases" / "value=1"
-        lembas_dir = case_dir / "lembas"
+        lembas_dir = case_dir / ".lembas"
         lembas_dir.mkdir(parents=True)
 
         case_toml = lembas_dir / "case.toml"


### PR DESCRIPTION
## Summary
- Renames the internal case metadata directory from `lembas/` to `.lembas/`
- Hidden directory is more appropriate for internal metadata that users shouldn't manually edit

## Test plan
- [x] All existing tests updated and passing