### PR TITLE
feat: Add JSON Schema extraction for Case handlers

### DIFF
--- a/src/lembas/__init__.py
+++ b/src/lembas/__init__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from lembas._version import __version__
 from lembas.case import Case
 from lembas.case import CaseList
@@ -24,11 +26,16 @@ __all__ = [
 ]
 
 
-def load_local_plugins() -> None:
-    """Load local plugins defined in [local-plugins] section of lembas.toml.
+def load_local_plugins(plugin: Path | None = None) -> None:
+    """Load plugins for the current project.
 
-    Call this at the start of run.py to load any plugins defined locally in the project.
+    If a plugin path is provided, load from that file directly.
+    Otherwise, load plugins defined in [local-plugins] section of lembas.toml.
+
     After calling, case handlers will be available in the registry.
+
+    Args:
+        plugin: Optional path to a plugin file to load instead of using lembas.toml.
 
     Example:
         from lembas import load_local_plugins, registry
@@ -37,6 +44,10 @@ def load_local_plugins() -> None:
         PlaningPlateCase = registry.get("PlaningPlateCase")
     """
     from pathlib import Path
+
+    if plugin is not None:
+        load_plugins_from_file(plugin)
+        return
 
     from lembas.manifest import load_lembas_manifest
 

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -39,6 +39,13 @@ LEMBAS_CASE_TOML_FILENAME = Path(".lembas", "case.toml")
 LEMBAS_STATUS_FILENAME = Path(".lembas", "status.json")
 
 TCase = TypeVar("TCase", bound="Case")
+
+
+def _get_docstring_summary(obj: Any) -> str | None:
+    """Return the first line of an object's docstring, or None if no docstring."""
+    if obj.__doc__:
+        return obj.__doc__.strip().splitlines()[0]
+    return None
 RawCaseStepMethod = Callable[[TCase], None]
 
 
@@ -58,6 +65,11 @@ class CaseStep:
     def name(self) -> str:
         """The name of the case step."""
         return self._func.__name__
+
+    @property
+    def summary(self) -> str | None:
+        """First line of the step's docstring, or None."""
+        return _get_docstring_summary(self._func)
 
     @staticmethod
     def _validate_condition(
@@ -138,6 +150,11 @@ class Case:
         mod = inspect.getmodule(cls)
         mod_prefix = mod.__name__ + "." if mod is not None else ""
         return mod_prefix + cls.__qualname__
+
+    @classmethod
+    def get_summary(cls) -> str | None:
+        """First line of the Case class's docstring, or None."""
+        return _get_docstring_summary(cls)
 
     @cached_property
     def id(self) -> str:

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -46,6 +46,8 @@ def _get_docstring_summary(obj: Any) -> str | None:
     if obj.__doc__:
         return obj.__doc__.strip().splitlines()[0]
     return None
+
+
 RawCaseStepMethod = Callable[[TCase], None]
 
 

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -572,27 +572,27 @@ def handlers_show(
 
     console.print(f"[bold]{handler_name}[/bold]")
     if summary := handler_cls.get_summary():
-        console.print(f"  {summary}")
+        console.print(f"    {summary}")
     console.print()
 
     # Show inputs
-    console.print("[bold]Inputs:[/bold]")
+    console.print("  [bold]Inputs:[/bold]")
     for value in handler_cls.__dict__.values():
         if isinstance(value, InputParameter):
-            console.print(f"  {value.display_string}")
+            console.print(f"    {value.display_string}")
     console.print()
 
     # Show steps
-    console.print("[bold]Steps:[/bold]")
+    console.print("  [bold]Steps:[/bold]")
     for name, value in handler_cls.__dict__.items():
         if isinstance(value, CaseStep):
             requires = f" (requires: {', '.join(value.requires)})" if value.requires else ""
-            console.print(f"  {name}{requires}")
+            console.print(f"    {name}{requires}")
     console.print()
 
     # Show results
-    console.print("[bold]Results:[/bold]")
+    console.print("  [bold]Results:[/bold]")
     for _method_name, method_func in handler_cls.__dict__.items():
         provides = getattr(method_func, "_provides_results", None)
         if provides:
-            console.print(f"  {', '.join(provides)}")
+            console.print(f"    {', '.join(provides)}")

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -28,9 +28,9 @@ app = typer.Typer(add_completion=False)
 cases_app = typer.Typer(help="Manage study cases")
 app.add_typer(cases_app, name="cases")
 
-# Subcommand group for plugin/handler management
-handlers_app = typer.Typer(help="Manage case handlers")
-app.add_typer(handlers_app, name="handlers")
+# Subcommand group for schema management
+schema_app = typer.Typer(help="Manage case handler schemas")
+app.add_typer(schema_app, name="schema")
 
 
 class Okay(typer.Exit):
@@ -504,11 +504,11 @@ def cases_clean(
 
 
 # =============================================================================
-# Handlers commands
+# Schema commands
 # =============================================================================
 
 
-@handlers_app.command("list")
+@schema_app.command("list")
 def handlers_list(
     plugin: Path | None = typer.Option(  # noqa: B008
         None, help="Path to plugin file to load handlers from"
@@ -537,7 +537,7 @@ def handlers_list(
     console.print(table)
 
 
-@handlers_app.command("show")
+@schema_app.command("show")
 def handlers_show(
     handler_name: str = typer.Argument(help="Name of the handler to show"),  # noqa: B008
     plugin: Path | None = typer.Option(  # noqa: B008
@@ -560,7 +560,7 @@ def handlers_show(
         handler_cls = registry.get(handler_name)
     except CaseHandlerNotFound as err:
         raise Abort(
-            f"Handler '{handler_name}' not found. Use 'lembas handlers list' to see available handlers."
+            f"Handler '{handler_name}' not found. Use 'lembas schema list' to see available handlers."
         ) from err
 
     if as_json_schema:

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -18,7 +18,6 @@ from lembas.manifest import is_pixi_manifest_stale
 from lembas.manifest import load_lembas_manifest
 from lembas.manifest import write_pixi_manifest
 from lembas.plugins import CaseHandlerNotFound
-from lembas.plugins import load_plugins_from_file
 from lembas.plugins import registry
 
 console = Console()
@@ -347,8 +346,9 @@ def run_case(
     plugin: Path | None = None,
 ) -> None:
     """Run a single case of a given case handler type (low-level)."""
-    if plugin is not None:
-        load_plugins_from_file(plugin)
+    from lembas import load_local_plugins
+
+    load_local_plugins(plugin)
 
     try:
         class_ = registry.get(case_handler_name)
@@ -508,21 +508,6 @@ def cases_clean(
 # =============================================================================
 
 
-def _load_plugins_for_schema(plugin: Path | None) -> None:
-    """Load plugins for schema commands.
-
-    If --plugin is provided, load from that file.
-    Otherwise, auto-load from lembas.toml [local-plugins] if present.
-    """
-    if plugin:
-        console.print(f"Loading handlers from {plugin}")
-        load_plugins_from_file(plugin)
-    elif get_lembas_manifest_path().exists():
-        from lembas import load_local_plugins
-
-        load_local_plugins()
-
-
 @schema_app.command("list")
 def handlers_list(
     plugin: Path | None = typer.Option(  # noqa: B008
@@ -530,7 +515,9 @@ def handlers_list(
     ),
 ) -> None:
     """List available case handlers."""
-    _load_plugins_for_schema(plugin)
+    from lembas import load_local_plugins
+
+    load_local_plugins(plugin)
 
     handlers = registry.get_all()
     if not handlers:
@@ -563,9 +550,10 @@ def handlers_show(
     """Show details of a case handler."""
     import json
 
+    from lembas import load_local_plugins
     from lembas.schema import extract_handler_schema
 
-    _load_plugins_for_schema(plugin)
+    load_local_plugins(plugin)
 
     try:
         handler_cls = registry.get(handler_name)

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -556,8 +556,8 @@ def handlers_show(
     plugin: Path | None = typer.Option(  # noqa: B008
         None, help="Path to plugin file to load handlers from"
     ),
-    as_json_schema: bool = typer.Option(  # noqa: B008
-        False, "--as-json-schema", help="Output as JSON Schema"
+    as_json: bool = typer.Option(  # noqa: B008
+        False, "--json", help="Output as JSON Schema"
     ),
 ) -> None:
     """Show details of a case handler."""
@@ -574,7 +574,7 @@ def handlers_show(
             f"Handler '{handler_name}' not found. Use 'lembas schema list' to see available handlers."
         ) from err
 
-    if as_json_schema:
+    if as_json:
         schema = extract_handler_schema(handler_cls)
         console.print(json.dumps(schema, indent=2))
         return

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -28,6 +28,10 @@ app = typer.Typer(add_completion=False)
 cases_app = typer.Typer(help="Manage study cases")
 app.add_typer(cases_app, name="cases")
 
+# Subcommand group for plugin/handler management
+handlers_app = typer.Typer(help="Manage case handlers")
+app.add_typer(handlers_app, name="handlers")
+
 
 class Okay(typer.Exit):
     """Prints an optional message to the console, before cleanly exiting."""
@@ -497,3 +501,104 @@ def cases_clean(
     console.print(
         f"[green]Cleaned index:[/green] removed {len(result.stale_entries)} stale entries."
     )
+
+
+# =============================================================================
+# Handlers commands
+# =============================================================================
+
+
+@handlers_app.command("list")
+def handlers_list(
+    plugin: Path | None = typer.Option(  # noqa: B008
+        None, help="Path to plugin file to load handlers from"
+    ),
+) -> None:
+    """List available case handlers."""
+    if plugin:
+        console.print(f"Loading handlers from {plugin}")
+        load_plugins_from_file(plugin)
+
+    handlers = registry.get_all()
+    if not handlers:
+        console.print("No handlers registered.")
+        return
+
+    table = Table(title="Available Case Handlers")
+    table.add_column("Handler", style="cyan")
+    table.add_column("Description")
+
+    for name, cls in sorted(handlers.items()):
+        desc = ""
+        if cls.__doc__:
+            desc = cls.__doc__.strip().split("\n")[0]
+        table.add_row(name, desc)
+
+    console.print(table)
+
+
+@handlers_app.command("show")
+def handlers_show(
+    handler_name: str = typer.Argument(help="Name of the handler to show"),  # noqa: B008
+    plugin: Path | None = typer.Option(  # noqa: B008
+        None, help="Path to plugin file to load handlers from"
+    ),
+    as_json_schema: bool = typer.Option(  # noqa: B008
+        False, "--as-json-schema", help="Output as JSON Schema"
+    ),
+) -> None:
+    """Show details of a case handler."""
+    import json
+
+    from lembas.schema import extract_handler_schema
+
+    if plugin:
+        console.print(f"Loading handlers from {plugin}")
+        load_plugins_from_file(plugin)
+
+    try:
+        handler_cls = registry.get(handler_name)
+    except CaseHandlerNotFound as err:
+        raise Abort(
+            f"Handler '{handler_name}' not found. Use 'lembas handlers list' to see available handlers."
+        ) from err
+
+    if as_json_schema:
+        schema = extract_handler_schema(handler_cls)
+        console.print(json.dumps(schema, indent=2))
+        return
+
+    # Default: show handler info in a readable format
+    from lembas.case import CaseStep
+    from lembas.param import InputParameter
+
+    console.print(f"[bold]{handler_name}[/bold]")
+    if handler_cls.__doc__:
+        console.print(f"  {handler_cls.__doc__.strip().split(chr(10))[0]}")
+    console.print()
+
+    # Show inputs
+    console.print("[bold]Inputs:[/bold]")
+    for name, value in handler_cls.__dict__.items():
+        if isinstance(value, InputParameter):
+            type_name = value._type.__name__ if value._type else "any"
+            bounds = ""
+            if value._min_value is not None or value._max_value is not None:
+                bounds = f" [{value._min_value}, {value._max_value}]"
+            console.print(f"  {name}: {type_name}{bounds}")
+    console.print()
+
+    # Show steps
+    console.print("[bold]Steps:[/bold]")
+    for name, value in handler_cls.__dict__.items():
+        if isinstance(value, CaseStep):
+            requires = f" (requires: {', '.join(value.requires)})" if value.requires else ""
+            console.print(f"  {name}{requires}")
+    console.print()
+
+    # Show results
+    console.print("[bold]Results:[/bold]")
+    for _method_name, method_func in handler_cls.__dict__.items():
+        provides = getattr(method_func, "_provides_results", None)
+        if provides:
+            console.print(f"  {', '.join(provides)}")

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -549,6 +549,7 @@ def handlers_show(
 ) -> None:
     """Show details of a case handler."""
     import json
+    import sys
 
     from lembas import load_local_plugins
     from lembas.schema import extract_handler_schema
@@ -564,7 +565,8 @@ def handlers_show(
 
     if as_json:
         schema = extract_handler_schema(handler_cls)
-        console.print(json.dumps(schema, indent=2))
+        indent = 2 if sys.stdout.isatty() else None
+        print(json.dumps(schema, indent=indent))
         return
 
     # Default: show handler info in a readable format

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -577,13 +577,9 @@ def handlers_show(
 
     # Show inputs
     console.print("[bold]Inputs:[/bold]")
-    for name, value in handler_cls.__dict__.items():
+    for value in handler_cls.__dict__.values():
         if isinstance(value, InputParameter):
-            type_name = value._type.__name__ if value._type else "any"
-            bounds = ""
-            if value._min_value is not None or value._max_value is not None:
-                bounds = f" [{value._min_value}, {value._max_value}]"
-            console.print(f"  {name}: {type_name}{bounds}")
+            console.print(f"  {value.display_string}")
     console.print()
 
     # Show steps

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -529,10 +529,7 @@ def handlers_list(
     table.add_column("Description")
 
     for name, cls in sorted(handlers.items()):
-        desc = ""
-        if cls.__doc__:
-            desc = cls.__doc__.strip().splitlines()[0]
-        table.add_row(name, desc)
+        table.add_row(name, cls.get_summary() or "")
 
     console.print(table)
 
@@ -574,8 +571,8 @@ def handlers_show(
     from lembas.param import InputParameter
 
     console.print(f"[bold]{handler_name}[/bold]")
-    if handler_cls.__doc__:
-        console.print(f"  {handler_cls.__doc__.strip().splitlines()[0]}")
+    if summary := handler_cls.get_summary():
+        console.print(f"  {summary}")
     console.print()
 
     # Show inputs

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -531,7 +531,7 @@ def handlers_list(
     for name, cls in sorted(handlers.items()):
         desc = ""
         if cls.__doc__:
-            desc = cls.__doc__.strip().split("\n")[0]
+            desc = cls.__doc__.strip().splitlines()[0]
         table.add_row(name, desc)
 
     console.print(table)
@@ -575,7 +575,7 @@ def handlers_show(
 
     console.print(f"[bold]{handler_name}[/bold]")
     if handler_cls.__doc__:
-        console.print(f"  {handler_cls.__doc__.strip().split(chr(10))[0]}")
+        console.print(f"  {handler_cls.__doc__.strip().splitlines()[0]}")
     console.print()
 
     # Show inputs

--- a/src/lembas/cli.py
+++ b/src/lembas/cli.py
@@ -508,6 +508,21 @@ def cases_clean(
 # =============================================================================
 
 
+def _load_plugins_for_schema(plugin: Path | None) -> None:
+    """Load plugins for schema commands.
+
+    If --plugin is provided, load from that file.
+    Otherwise, auto-load from lembas.toml [local-plugins] if present.
+    """
+    if plugin:
+        console.print(f"Loading handlers from {plugin}")
+        load_plugins_from_file(plugin)
+    elif get_lembas_manifest_path().exists():
+        from lembas import load_local_plugins
+
+        load_local_plugins()
+
+
 @schema_app.command("list")
 def handlers_list(
     plugin: Path | None = typer.Option(  # noqa: B008
@@ -515,9 +530,7 @@ def handlers_list(
     ),
 ) -> None:
     """List available case handlers."""
-    if plugin:
-        console.print(f"Loading handlers from {plugin}")
-        load_plugins_from_file(plugin)
+    _load_plugins_for_schema(plugin)
 
     handlers = registry.get_all()
     if not handlers:
@@ -552,9 +565,7 @@ def handlers_show(
 
     from lembas.schema import extract_handler_schema
 
-    if plugin:
-        console.print(f"Loading handlers from {plugin}")
-        load_plugins_from_file(plugin)
+    _load_plugins_for_schema(plugin)
 
     try:
         handler_cls = registry.get(handler_name)

--- a/src/lembas/param.py
+++ b/src/lembas/param.py
@@ -127,3 +127,31 @@ class InputParameter:
         if isinstance(value, float):
             return format(value, ".6g")
         return str(value)
+
+    def to_json_schema(self) -> dict[str, Any]:
+        """Convert this parameter to a JSON Schema property definition."""
+        type_map = {
+            str: "string",
+            int: "integer",
+            float: "number",
+            bool: "boolean",
+            list: "array",
+            dict: "object",
+        }
+        schema: dict[str, Any] = {"type": type_map.get(self._type, "string")}
+
+        if self._min_value is not None:
+            schema["minimum"] = self._min_value
+        if self._max_value is not None:
+            schema["maximum"] = self._max_value
+        if self._default != _NoDefault:
+            schema["default"] = self._default
+        if self._short_name:
+            schema["x-lembas-short-name"] = self._short_name
+
+        return schema
+
+    @property
+    def is_required(self) -> bool:
+        """Whether this parameter is required (has no default)."""
+        return self._default == _NoDefault

--- a/src/lembas/param.py
+++ b/src/lembas/param.py
@@ -155,3 +155,16 @@ class InputParameter:
     def is_required(self) -> bool:
         """Whether this parameter is required (has no default)."""
         return self._default == _NoDefault
+
+    @property
+    def type_name(self) -> str:
+        """Human-readable type name."""
+        return self._type.__name__ if self._type else "any"
+
+    @property
+    def display_string(self) -> str:
+        """Human-readable representation for CLI display."""
+        result = f"{self._name}: {self.type_name}"
+        if self._min_value is not None or self._max_value is not None:
+            result += f" [{self._min_value}, {self._max_value}]"
+        return result

--- a/src/lembas/plugins.py
+++ b/src/lembas/plugins.py
@@ -10,7 +10,6 @@ from types import ModuleType
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 from pluggy import PluginManager
-from rich import print
 
 from lembas import Case
 

--- a/src/lembas/plugins.py
+++ b/src/lembas/plugins.py
@@ -90,14 +90,12 @@ def load_plugins_from_file(plugin_path: Path) -> None:
 
     """
 
-    print("Loading plugins")
     plugin_path = plugin_path.resolve()
     mod = _load_module_from_path(plugin_path)
 
     for name, obj in mod.__dict__.items():
         if inspect.isclass(obj) and issubclass(obj, Case) and obj != Case:
             registry.add(obj)
-            print(f"Found [bold]{name}[/bold] in {plugin_path}")
 
 
 hookspec = HookspecMarker("lembas")

--- a/src/lembas/plugins.py
+++ b/src/lembas/plugins.py
@@ -51,6 +51,10 @@ class CaseHandlerRegistry:
         """Clear the case handler registry."""
         self._registry.clear()
 
+    def get_all(self) -> dict[str, type[Case]]:
+        """Return all registered case handlers."""
+        return dict(self._registry)
+
 
 registry = CaseHandlerRegistry()
 

--- a/src/lembas/plugins.py
+++ b/src/lembas/plugins.py
@@ -10,8 +10,11 @@ from types import ModuleType
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 from pluggy import PluginManager
+from rich.console import Console
 
 from lembas import Case
+
+stderr = Console(stderr=True)
 
 __all__ = ["register", "registry", "load_plugins_from_file", "CaseHandlerNotFound"]
 
@@ -95,6 +98,7 @@ def load_plugins_from_file(plugin_path: Path) -> None:
     for name, obj in mod.__dict__.items():
         if inspect.isclass(obj) and issubclass(obj, Case) and obj != Case:
             registry.add(obj)
+            stderr.print(f"Loaded [bold]{name}[/bold] from {plugin_path}")
 
 
 hookspec = HookspecMarker("lembas")

--- a/src/lembas/schema.py
+++ b/src/lembas/schema.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from lembas.case import Case
 
 SCHEMA_VERSION = "v1"
-SCHEMA_BASE_URL = "https://lembas.fly.dev/schemas"
+SCHEMA_BASE_URL = "https://lembas.matt-kramer.com/schemas"
 
 
 def _get_git_ref() -> dict[str, Any] | None:

--- a/src/lembas/schema.py
+++ b/src/lembas/schema.py
@@ -115,7 +115,7 @@ def extract_steps_schema(case_cls: type[Case]) -> list[dict[str, Any]]:
 
             # Get docstring if available
             if value._func.__doc__:
-                step_info["description"] = value._func.__doc__.strip().split("\n")[0]
+                step_info["description"] = value._func.__doc__.strip().splitlines()[0]
 
             # Check if there's a condition (we can't serialize lambdas, but we can flag it)
             # The condition is stored as a callable, check if it's not the default "always true"
@@ -160,7 +160,7 @@ def extract_handler_schema(
     # Get description from docstring
     description = None
     if case_cls.__doc__:
-        description = case_cls.__doc__.strip().split("\n")[0]
+        description = case_cls.__doc__.strip().splitlines()[0]
 
     schema: dict[str, Any] = {
         "title": handler_name,

--- a/src/lembas/schema.py
+++ b/src/lembas/schema.py
@@ -1,0 +1,232 @@
+"""JSON Schema extraction for Case handlers.
+
+Generates JSON Schema representations of Case handlers for the schema registry.
+Schemas are content-addressed by fingerprint (SHA-256 of canonical JSON).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from typing import TYPE_CHECKING
+from typing import Any
+
+if TYPE_CHECKING:
+    from lembas.case import Case
+
+SCHEMA_VERSION = "v1"
+SCHEMA_BASE_URL = "https://lembas.fly.dev/schemas"
+
+
+def _get_git_ref() -> dict[str, Any] | None:
+    """Get git reference for current working directory.
+
+    Returns:
+        Dict with git_ref and dirty flag, or None if not in a git repo.
+    """
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        return {
+            "git_ref": commit,
+            "dirty": bool(status),
+        }
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def extract_input_schema(case_cls: type[Case]) -> dict[str, Any]:
+    """Extract JSON Schema for a Case handler's inputs.
+
+    Returns a valid JSON Schema object for the inputs.
+    """
+    from lembas.param import InputParameter
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for name, value in case_cls.__dict__.items():
+        if isinstance(value, InputParameter):
+            properties[name] = value.to_json_schema()
+            if value.is_required:
+                required.append(name)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": sorted(required),
+    }
+
+
+def extract_result_schema(case_cls: type[Case]) -> dict[str, Any]:
+    """Extract JSON Schema for a Case handler's results.
+
+    Returns a valid JSON Schema object for the results.
+    """
+    properties: dict[str, Any] = {}
+
+    for _method_name, method_func in case_cls.__dict__.items():
+        provides = getattr(method_func, "_provides_results", None)
+        if not provides:
+            continue
+
+        # Each name in provides is a result field
+        for name in provides:
+            # Default to number type for results
+            # Could be enhanced to introspect return type annotations
+            properties[name] = {
+                "type": "number",
+            }
+
+    return {
+        "type": "object",
+        "properties": properties,
+    }
+
+
+def extract_steps_schema(case_cls: type[Case]) -> list[dict[str, Any]]:
+    """Extract step definitions for a Case handler.
+
+    Returns a list of step objects with name, requires, and condition info.
+    """
+    from lembas.case import CaseStep
+
+    steps: list[dict[str, Any]] = []
+
+    for name, value in case_cls.__dict__.items():
+        if isinstance(value, CaseStep):
+            step_info: dict[str, Any] = {
+                "name": name,
+                "requires": value.requires if value.requires else [],
+            }
+
+            # Get docstring if available
+            if value._func.__doc__:
+                step_info["description"] = value._func.__doc__.strip().split("\n")[0]
+
+            # Check if there's a condition (we can't serialize lambdas, but we can flag it)
+            # The condition is stored as a callable, check if it's not the default "always true"
+            if value._condition is not None:
+                # Check if it's not the default lambda that always returns True
+                # We do this by checking if the condition function is different from the default
+                try:
+                    # Try to detect if there's a real condition by checking if it's a closure
+                    if hasattr(value._condition, "__closure__") and value._condition.__closure__:
+                        step_info["has_condition"] = True
+                except Exception:
+                    pass
+
+            steps.append(step_info)
+
+    return steps
+
+
+def extract_handler_schema(
+    case_cls: type[Case],
+    *,
+    base_url: str = SCHEMA_BASE_URL,
+    source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Extract full JSON Schema for a Case handler.
+
+    Args:
+        case_cls: The Case subclass to extract schema from.
+        base_url: Base URL for schema references.
+        source: Source metadata (git_ref, plugin version, etc.)
+
+    Returns:
+        Complete JSON Schema with inputs, results, steps, and metadata.
+    """
+    inputs_schema = extract_input_schema(case_cls)
+    results_schema = extract_result_schema(case_cls)
+    steps_schema = extract_steps_schema(case_cls)
+
+    # Build the schema without fingerprint first
+    handler_name = case_cls.__name__
+
+    # Get description from docstring
+    description = None
+    if case_cls.__doc__:
+        description = case_cls.__doc__.strip().split("\n")[0]
+
+    schema: dict[str, Any] = {
+        "title": handler_name,
+        "inputs": inputs_schema,
+        "results": results_schema,
+        "steps": steps_schema,
+    }
+
+    if description:
+        schema["description"] = description
+
+    # Compute fingerprint from canonical schema (without metadata)
+    fingerprint = compute_fingerprint(schema)
+
+    # Now build the full schema with all metadata
+    full_schema: dict[str, Any] = {
+        "$schema": f"{base_url}/case-handler/{SCHEMA_VERSION}",
+        "$id": f"{base_url}/handlers/{handler_name}/{fingerprint}",
+        "title": handler_name,
+        "x-lembas-fingerprint": fingerprint,
+    }
+
+    if description:
+        full_schema["description"] = description
+
+    if source:
+        full_schema["x-lembas-source"] = source
+
+    full_schema["inputs"] = inputs_schema
+    full_schema["results"] = results_schema
+    full_schema["steps"] = steps_schema
+
+    return full_schema
+
+
+def compute_fingerprint(schema: dict[str, Any]) -> str:
+    """Compute content-addressable fingerprint for a schema.
+
+    Uses SHA-256 of canonical JSON (sorted keys, no whitespace).
+    Returns first 16 hex characters.
+    """
+    # Only hash the semantic content (inputs + results + steps), not metadata
+    content = {
+        "title": schema.get("title"),
+        "inputs": schema.get("inputs"),
+        "results": schema.get("results"),
+        "steps": schema.get("steps"),
+    }
+    canonical = json.dumps(content, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def extract_all_handler_schemas(
+    case_classes: list[type[Case]],
+    *,
+    base_url: str = SCHEMA_BASE_URL,
+) -> list[dict[str, Any]]:
+    """Extract schemas from multiple Case handlers.
+
+    Automatically detects git ref for local plugins.
+    """
+    source = _get_git_ref()
+
+    schemas = []
+    for case_cls in case_classes:
+        schema = extract_handler_schema(case_cls, base_url=base_url, source=source)
+        schemas.append(schema)
+
+    return schemas

--- a/src/lembas/schema.py
+++ b/src/lembas/schema.py
@@ -113,9 +113,8 @@ def extract_steps_schema(case_cls: type[Case]) -> list[dict[str, Any]]:
                 "requires": value.requires if value.requires else [],
             }
 
-            # Get docstring if available
-            if value._func.__doc__:
-                step_info["description"] = value._func.__doc__.strip().splitlines()[0]
+            if summary := value.summary:
+                step_info["description"] = summary
 
             # Check if there's a condition (we can't serialize lambdas, but we can flag it)
             # The condition is stored as a callable, check if it's not the default "always true"
@@ -157,10 +156,7 @@ def extract_handler_schema(
     # Build the schema without fingerprint first
     handler_name = case_cls.__name__
 
-    # Get description from docstring
-    description = None
-    if case_cls.__doc__:
-        description = case_cls.__doc__.strip().splitlines()[0]
+    description = case_cls.get_summary()
 
     schema: dict[str, Any] = {
         "title": handler_name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,13 +410,13 @@ class TestSchemaShowCommand:
         assert "Steps:" in result.stdout
         assert "set_has_been_run" in result.stdout
 
-    def test_schema_show_json(
-        self, invoke_cli: CLIInvoker, plugin_module_path: Path
-    ) -> None:
+    def test_schema_show_json(self, invoke_cli: CLIInvoker, plugin_module_path: Path) -> None:
         """Outputs valid JSON Schema with --json flag."""
         import json
 
-        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json")
+        result = invoke_cli(
+            "schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json"
+        )
         assert result.exit_code == 0
 
         # Should be valid JSON
@@ -432,7 +432,9 @@ class TestSchemaShowCommand:
         """JSON Schema includes input parameter bounds."""
         import json
 
-        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json")
+        result = invoke_cli(
+            "schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json"
+        )
         schema = json.loads(result.stdout)
 
         my_param = schema["inputs"]["properties"]["my_param"]
@@ -444,7 +446,9 @@ class TestSchemaShowCommand:
         self, invoke_cli: CLIInvoker, plugin_module_path: Path
     ) -> None:
         """JSON output is compact (no indentation) when not a TTY (e.g., piped to jq)."""
-        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json")
+        result = invoke_cli(
+            "schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json"
+        )
         assert result.exit_code == 0
 
         # CliRunner is not a TTY, so output should be compact (single line)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -358,3 +358,101 @@ class TestCasesReindexCommand:
         # Verify index file was created
         index_file = run_path / ".lembas" / "cases.json"
         assert index_file.exists()
+
+
+class TestSchemaListCommand:
+    """Tests for `lembas schema list` command."""
+
+    def test_schema_list_empty(self, invoke_cli: CLIInvoker) -> None:
+        """With no plugins loaded, shows no handlers."""
+        result = invoke_cli("schema", "list")
+        assert result.exit_code == 0
+        assert "No handlers registered" in result.stdout
+
+    def test_schema_list_with_plugin(
+        self, invoke_cli: CLIInvoker, plugin_module_path: Path
+    ) -> None:
+        """Lists handlers from a plugin file."""
+        result = invoke_cli("schema", "list", "--plugin", str(plugin_module_path))
+        assert result.exit_code == 0
+        assert "MyCase" in result.stdout
+
+    def test_schema_list_from_lembas_toml(
+        self, invoke_cli: CLIInvoker, run_path: Path, plugin_module_path: Path
+    ) -> None:
+        """Auto-loads handlers from [local-plugins] in lembas.toml."""
+        lembas_toml = run_path / "lembas.toml"
+        lembas_toml.write_text(f'[local-plugins]\nplugin = "{plugin_module_path.name}"\n')
+
+        result = invoke_cli("schema", "list")
+        assert result.exit_code == 0
+        assert "MyCase" in result.stdout
+
+
+class TestSchemaShowCommand:
+    """Tests for `lembas schema show` command."""
+
+    def test_schema_show_not_found(self, invoke_cli: CLIInvoker) -> None:
+        """Shows error when handler not found."""
+        result = invoke_cli("schema", "show", "NonexistentCase")
+        assert result.exit_code == 1
+        assert "not found" in result.stdout
+
+    def test_schema_show_human_readable(
+        self, invoke_cli: CLIInvoker, plugin_module_path: Path
+    ) -> None:
+        """Shows handler details in human-readable format."""
+        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path))
+        assert result.exit_code == 0
+        assert "MyCase" in result.stdout
+        assert "Inputs:" in result.stdout
+        assert "my_param" in result.stdout
+        assert "Steps:" in result.stdout
+        assert "set_has_been_run" in result.stdout
+
+    def test_schema_show_json(
+        self, invoke_cli: CLIInvoker, plugin_module_path: Path
+    ) -> None:
+        """Outputs valid JSON Schema with --json flag."""
+        import json
+
+        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json")
+        assert result.exit_code == 0
+
+        # Should be valid JSON
+        schema = json.loads(result.stdout)
+        assert schema["title"] == "MyCase"
+        assert "inputs" in schema
+        assert "steps" in schema
+        assert "x-lembas-fingerprint" in schema
+
+    def test_schema_show_json_has_input_bounds(
+        self, invoke_cli: CLIInvoker, plugin_module_path: Path
+    ) -> None:
+        """JSON Schema includes input parameter bounds."""
+        import json
+
+        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json")
+        schema = json.loads(result.stdout)
+
+        my_param = schema["inputs"]["properties"]["my_param"]
+        assert my_param["type"] == "number"
+        assert my_param["minimum"] == 2.0
+        assert my_param["maximum"] == 5.0
+
+    def test_schema_show_json_compact_when_not_tty(
+        self, invoke_cli: CLIInvoker, plugin_module_path: Path
+    ) -> None:
+        """JSON output is compact (no indentation) when not a TTY (e.g., piped to jq)."""
+        result = invoke_cli("schema", "show", "MyCase", "--plugin", str(plugin_module_path), "--json")
+        assert result.exit_code == 0
+
+        # CliRunner is not a TTY, so output should be compact (single line)
+        lines = [line for line in result.stdout.strip().split("\n") if line]
+        assert len(lines) == 1, "JSON should be compact (single line) when piped"
+
+        # Verify it's still valid JSON
+        import json
+
+        schema = json.loads(result.stdout)
+        assert schema["title"] == "MyCase"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,191 @@
+"""Tests for JSON Schema extraction from Case handlers."""
+
+from __future__ import annotations
+
+import json
+
+from lembas import Case
+from lembas import InputParameter
+from lembas import step
+from lembas.results import result
+from lembas.schema import compute_fingerprint
+from lembas.schema import extract_handler_schema
+from lembas.schema import extract_input_schema
+from lembas.schema import extract_result_schema
+from lembas.schema import extract_steps_schema
+
+
+class SimpleCase(Case):
+    """A simple case for testing schema extraction."""
+
+    velocity: float = InputParameter(type=float, min=0.0, max=100.0)
+    angle: float = InputParameter(type=float, default=45.0)
+    name: str = InputParameter(type=str, default="test")
+    count: int = InputParameter(type=int, default=1)
+    enabled: bool = InputParameter(type=bool, default=True)
+
+    @step
+    def prepare(self) -> None:
+        """Prepare the simulation."""
+        pass
+
+    @step(requires="prepare")
+    def solve(self) -> None:
+        """Run the solver."""
+        pass
+
+    @step(requires="solve")
+    def post_process(self) -> None:
+        pass
+
+    @result("force", "moment")
+    def compute_loads(self) -> tuple[float, float]:
+        return 1.0, 2.0
+
+
+class TestExtractInputSchema:
+    def test_extracts_all_parameters(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        assert schema["type"] == "object"
+        assert set(schema["properties"].keys()) == {
+            "velocity",
+            "angle",
+            "name",
+            "count",
+            "enabled",
+        }
+
+    def test_required_parameters(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        assert schema["required"] == ["velocity"]
+
+    def test_float_parameter_schema(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        velocity = schema["properties"]["velocity"]
+        assert velocity["type"] == "number"
+        assert velocity["minimum"] == 0.0
+        assert velocity["maximum"] == 100.0
+        assert "default" not in velocity
+
+    def test_float_with_default_schema(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        angle = schema["properties"]["angle"]
+        assert angle["type"] == "number"
+        assert angle["default"] == 45.0
+
+    def test_string_parameter_schema(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        name = schema["properties"]["name"]
+        assert name["type"] == "string"
+        assert name["default"] == "test"
+
+    def test_int_parameter_schema(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        count = schema["properties"]["count"]
+        assert count["type"] == "integer"
+        assert count["default"] == 1
+
+    def test_bool_parameter_schema(self) -> None:
+        schema = extract_input_schema(SimpleCase)
+        enabled = schema["properties"]["enabled"]
+        assert enabled["type"] == "boolean"
+        assert enabled["default"] is True
+
+
+class TestExtractResultSchema:
+    def test_extracts_result_fields(self) -> None:
+        schema = extract_result_schema(SimpleCase)
+        assert schema["type"] == "object"
+        assert "force" in schema["properties"]
+        assert "moment" in schema["properties"]
+
+    def test_result_default_type(self) -> None:
+        schema = extract_result_schema(SimpleCase)
+        assert schema["properties"]["force"]["type"] == "number"
+        assert schema["properties"]["moment"]["type"] == "number"
+
+
+class TestExtractStepsSchema:
+    def test_extracts_all_steps(self) -> None:
+        steps = extract_steps_schema(SimpleCase)
+        step_names = {s["name"] for s in steps}
+        assert step_names == {"prepare", "solve", "post_process"}
+
+    def test_step_requires(self) -> None:
+        steps = extract_steps_schema(SimpleCase)
+        steps_by_name = {s["name"]: s for s in steps}
+
+        assert steps_by_name["prepare"]["requires"] == []
+        assert steps_by_name["solve"]["requires"] == ["prepare"]
+        assert steps_by_name["post_process"]["requires"] == ["solve"]
+
+    def test_step_description_from_docstring(self) -> None:
+        steps = extract_steps_schema(SimpleCase)
+        steps_by_name = {s["name"]: s for s in steps}
+
+        assert steps_by_name["prepare"]["description"] == "Prepare the simulation."
+        assert steps_by_name["solve"]["description"] == "Run the solver."
+        assert "description" not in steps_by_name["post_process"]
+
+
+class TestExtractHandlerSchema:
+    def test_full_schema_structure(self) -> None:
+        schema = extract_handler_schema(SimpleCase)
+
+        assert "$schema" in schema
+        assert "$id" in schema
+        assert schema["title"] == "SimpleCase"
+        assert schema["description"] == "A simple case for testing schema extraction."
+        assert "x-lembas-fingerprint" in schema
+        assert "inputs" in schema
+        assert "results" in schema
+        assert "steps" in schema
+
+    def test_schema_id_contains_fingerprint(self) -> None:
+        schema = extract_handler_schema(SimpleCase)
+        fingerprint = schema["x-lembas-fingerprint"]
+        assert fingerprint in schema["$id"]
+
+    def test_custom_base_url(self) -> None:
+        schema = extract_handler_schema(SimpleCase, base_url="https://example.com")
+        assert schema["$schema"].startswith("https://example.com")
+        assert schema["$id"].startswith("https://example.com")
+
+    def test_source_metadata(self) -> None:
+        source = {"git_ref": "abc123", "dirty": False}
+        schema = extract_handler_schema(SimpleCase, source=source)
+        assert schema["x-lembas-source"] == source
+
+
+class TestComputeFingerprint:
+    def test_fingerprint_is_16_hex_chars(self) -> None:
+        schema = extract_handler_schema(SimpleCase)
+        fingerprint = schema["x-lembas-fingerprint"]
+        assert len(fingerprint) == 16
+        assert all(c in "0123456789abcdef" for c in fingerprint)
+
+    def test_fingerprint_is_deterministic(self) -> None:
+        fp1 = compute_fingerprint(extract_handler_schema(SimpleCase))
+        fp2 = compute_fingerprint(extract_handler_schema(SimpleCase))
+        assert fp1 == fp2
+
+    def test_fingerprint_changes_with_schema(self) -> None:
+        class AnotherCase(Case):
+            x: float = InputParameter(type=float)
+
+        fp1 = compute_fingerprint(extract_handler_schema(SimpleCase))
+        fp2 = compute_fingerprint(extract_handler_schema(AnotherCase))
+        assert fp1 != fp2
+
+    def test_fingerprint_ignores_metadata(self) -> None:
+        schema1 = extract_handler_schema(SimpleCase, source={"git_ref": "abc"})
+        schema2 = extract_handler_schema(SimpleCase, source={"git_ref": "xyz"})
+        assert schema1["x-lembas-fingerprint"] == schema2["x-lembas-fingerprint"]
+
+
+class TestSchemaJsonSerialization:
+    def test_schema_is_json_serializable(self) -> None:
+        schema = extract_handler_schema(SimpleCase)
+        json_str = json.dumps(schema)
+        roundtrip = json.loads(json_str)
+        assert roundtrip == schema

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,11 +18,11 @@ from lembas.schema import extract_steps_schema
 class SimpleCase(Case):
     """A simple case for testing schema extraction."""
 
-    velocity: float = InputParameter(type=float, min=0.0, max=100.0)
-    angle: float = InputParameter(type=float, default=45.0)
-    name: str = InputParameter(type=str, default="test")
-    count: int = InputParameter(type=int, default=1)
-    enabled: bool = InputParameter(type=bool, default=True)
+    velocity = InputParameter(type=float, min=0.0, max=100.0)
+    angle = InputParameter(type=float, default=45.0)
+    name = InputParameter(type=str, default="test")
+    count = InputParameter(type=int, default=1)
+    enabled = InputParameter(type=bool, default=True)
 
     @step
     def prepare(self) -> None:
@@ -171,7 +171,7 @@ class TestComputeFingerprint:
 
     def test_fingerprint_changes_with_schema(self) -> None:
         class AnotherCase(Case):
-            x: float = InputParameter(type=float)
+            x = InputParameter(type=float)
 
         fp1 = compute_fingerprint(extract_handler_schema(SimpleCase))
         fp2 = compute_fingerprint(extract_handler_schema(AnotherCase))


### PR DESCRIPTION
## Summary

Adds JSON Schema extraction for Case handlers, enabling schema export for the platform registry.

### New CLI commands

- `lembas schema list` — list available case handlers
- `lembas schema show NAME` — show handler details (inputs, steps, results)
- `lembas schema show NAME --json` — export as JSON Schema

### Features

- Extracts inputs (types, bounds, defaults), results, and step DAG from Case handlers
- Content-addressable fingerprint (SHA-256[:16]) for schema versioning
- Auto-loads plugins from `[local-plugins]` in `lembas.toml`
- Compact JSON when piped, pretty-printed in terminal
- Logs loaded plugins to stderr (keeps stdout clean for piping)

### New APIs

- `InputParameter.to_json_schema()` — convert parameter to JSON Schema property
- `InputParameter.is_required` — whether parameter has no default
- `InputParameter.type_name` — human-readable type name
- `InputParameter.display_string` — formatted string for CLI display
- `Case.get_summary()` — first line of class docstring
- `CaseStep.summary` — first line of step docstring
- `load_local_plugins(plugin=None)` — load from lembas.toml or explicit path
- `CaseHandlerRegistry.get_all()` — get all registered handlers

### Example output

```
$ lembas schema show PlaningPlateCase
PlaningPlateCase
    Case handler for planing flat plate simulations.

  Inputs:
    froude_num: float [0.2, 3.0]
    angle_of_attack: float [-5.0, 20.0]

  Steps:
    create_input_files
    generate_mesh (requires: create_input_files)
    run_solver (requires: generate_mesh)

  Results:
    drag, lift, moment
```

## Test plan

- [x] All existing tests pass
- [x] New unit tests for schema extraction (21 tests)
- [x] Manual testing of CLI commands with example plugin
- [x] JSON output pipes cleanly to jq