### PR TITLE
feat: Incremental case runs with force parameter

### DIFF
--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -208,34 +208,6 @@ class Case:
         status["steps"][step_name] = {"completed_at": datetime.now(UTC).isoformat()}
         self._save_status(status)
 
-    def _extract_results(self) -> dict[str, Any]:
-        """Extract results from all @result-decorated methods.
-
-        Returns a dict mapping result name to value. Values are serialized:
-        - NamedTuple -> dict via _asdict()
-        - Objects with __dict__ -> their __dict__
-        - Other values -> as-is
-        """
-        results_dict: dict[str, Any] = {}
-        for _method_name, method_func in self.__class__.__dict__.items():
-            provides = getattr(method_func, "_provides_results", None)
-            if not provides:
-                continue
-            try:
-                result_val = method_func(self)
-                if not isinstance(result_val, tuple):
-                    result_val = (result_val,)
-                for name, val in zip(provides, result_val, strict=True):
-                    if hasattr(val, "_asdict"):
-                        results_dict[name] = val._asdict()
-                    elif hasattr(val, "__dict__"):
-                        results_dict[name] = val.__dict__
-                    else:
-                        results_dict[name] = val
-            except Exception as e:
-                self.log("Failed to extract result from %s: %s", _method_name, e)
-        return results_dict
-
     @classmethod
     def _get_input_parameters_by_declaration_order(cls) -> list[InputParameter]:
         """Get InputParameters in their declaration order.
@@ -354,15 +326,9 @@ class Case:
             step_method(self)
             self._mark_step_complete(step_method.name)
 
-        # Mark overall completion and save results
+        # Mark overall completion
         status = self._load_status() or {}
         status["completed_at"] = datetime.now(UTC).isoformat()
-
-        # Extract and save results
-        results_dict = self._extract_results()
-        if results_dict:
-            status["results"] = results_dict
-
         self._save_status(status)
 
     def _check_index_sync(self) -> None:

--- a/src/lembas/case.py
+++ b/src/lembas/case.py
@@ -208,6 +208,34 @@ class Case:
         status["steps"][step_name] = {"completed_at": datetime.now(UTC).isoformat()}
         self._save_status(status)
 
+    def _extract_results(self) -> dict[str, Any]:
+        """Extract results from all @result-decorated methods.
+
+        Returns a dict mapping result name to value. Values are serialized:
+        - NamedTuple -> dict via _asdict()
+        - Objects with __dict__ -> their __dict__
+        - Other values -> as-is
+        """
+        results_dict: dict[str, Any] = {}
+        for _method_name, method_func in self.__class__.__dict__.items():
+            provides = getattr(method_func, "_provides_results", None)
+            if not provides:
+                continue
+            try:
+                result_val = method_func(self)
+                if not isinstance(result_val, tuple):
+                    result_val = (result_val,)
+                for name, val in zip(provides, result_val, strict=True):
+                    if hasattr(val, "_asdict"):
+                        results_dict[name] = val._asdict()
+                    elif hasattr(val, "__dict__"):
+                        results_dict[name] = val.__dict__
+                    else:
+                        results_dict[name] = val
+            except Exception as e:
+                self.log("Failed to extract result from %s: %s", _method_name, e)
+        return results_dict
+
     @classmethod
     def _get_input_parameters_by_declaration_order(cls) -> list[InputParameter]:
         """Get InputParameters in their declaration order.
@@ -290,31 +318,51 @@ class Case:
         with case_summary_file.open("w") as fp:
             toml.dump(contents, fp)
 
-    def run(self) -> None:
+    def run(self, *, force: bool = False) -> None:
         """Run the case.
 
         If this method is not overridden, the default behavior is to run all the methods
         decorated with ``@step``.
 
+        Args:
+            force: If True, run all steps even if already completed.
+                   If False (default), skip already-completed steps.
         """
         from datetime import datetime
 
         self._check_index_sync()
+
+        # Check if already complete
+        if not force and self.has_run:
+            self.log("Case %s already complete, skipping", self.short_id)
+            return
+
         self.log("Running %s", self)
         self._write_lembas_file()
 
         # Initialize status
         status = self._load_status() or {"steps": {}}
+        completed_steps = set() if force else set(status.get("steps", {}).keys())
+
         status["started_at"] = datetime.now(UTC).isoformat()
         self._save_status(status)
 
         for step_method in self._sorted_steps:
+            if step_method.name in completed_steps:
+                self.log("Step '%s' already complete, skipping", step_method.name)
+                continue
             step_method(self)
             self._mark_step_complete(step_method.name)
 
-        # Mark overall completion
+        # Mark overall completion and save results
         status = self._load_status() or {}
         status["completed_at"] = datetime.now(UTC).isoformat()
+
+        # Extract and save results
+        results_dict = self._extract_results()
+        if results_dict:
+            status["results"] = results_dict
+
         self._save_status(status)
 
     def _check_index_sync(self) -> None:

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -107,14 +107,16 @@ def test_case_step_condition_is_met(case: MyCase) -> None:
     assert case.param_with_default == pytest.approx(5.0)
 
 
-def test_case_step_string_condition(case: MyCase) -> None:
+def test_case_step_string_condition(case: MyCase, tmp_path: Path) -> None:
     """The step with a simple string condition is run."""
+    case.case_dir = tmp_path
     case.run()
     assert case.step_has_been_triggered_by_string
 
 
-def test_case_step_string_condition_not(case: MyCase) -> None:
+def test_case_step_string_condition_not(case: MyCase, tmp_path: Path) -> None:
     """The step with a string "not" condition is run."""
+    case.case_dir = tmp_path
     case.run()
     assert case.step_has_been_triggered_by_string_not
 
@@ -192,6 +194,71 @@ def test_in_case_dir_changes_and_restores_cwd(case: MyCase, tmp_path: Path) -> N
     assert os.getcwd() == original_cwd
 
 
+class TestCaseRunBehavior:
+    """Tests for case run behavior: skipping completed cases/steps and force parameter."""
+
+    def test_run_skips_completed_case(self, case: MyCase, tmp_path: Path) -> None:
+        """Running a completed case a second time skips execution."""
+        case.case_dir = tmp_path
+        case.run()
+        assert case.first_step_has_been_run
+
+        # Reset the flag and run again
+        case.first_step_has_been_run = False
+        case.run()
+        # Should have been skipped
+        assert not case.first_step_has_been_run
+
+    def test_run_force_reruns_completed_case(self, tmp_path: Path) -> None:
+        """force=True reruns all steps even if already complete."""
+
+        class SimpleCase(Case):
+            run_count = 0
+
+            @step
+            def do_work(self) -> None:
+                self.run_count += 1
+
+        case = SimpleCase()
+        case.case_dir = tmp_path
+        case.run()
+        assert case.run_count == 1
+
+        # Run again without force - should skip
+        case.run()
+        assert case.run_count == 1
+
+        # Run with force - should run again
+        case.run(force=True)
+        assert case.run_count == 2
+
+    def test_run_saves_results_to_status(self, tmp_path: Path) -> None:
+        """Results from @result methods are saved to status.json."""
+        import json
+
+        from lembas.results import result
+
+        class CaseWithResults(Case):
+            value = InputParameter(type=float)
+
+            @step
+            def compute(self) -> None:
+                pass
+
+            @result("output")
+            def get_output(self) -> float:
+                return self.value * 2
+
+        case = CaseWithResults(value=5.0)
+        case.case_dir = tmp_path
+        case.run()
+
+        status_file = tmp_path / ".lembas" / "status.json"
+        assert status_file.exists()
+        status = json.loads(status_file.read_text())
+        assert status["results"] == {"output": 10.0}
+
+
 @pytest.fixture()
 def case_list() -> CaseList:
     return CaseList()
@@ -208,7 +275,8 @@ class TestCaseList:
         case_list.add(case)
         assert case in case_list
 
-    def test_run_all_cases(self, case_list: CaseList, case: MyCase) -> None:
+    def test_run_all_cases(self, case_list: CaseList, case: MyCase, tmp_path: Path) -> None:
+        case.case_dir = tmp_path
         case_list.add(case)
         assert not case.second_step_has_been_run
         case_list.run_all()

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -231,32 +231,6 @@ class TestCaseRunBehavior:
         case.run(force=True)
         assert case.run_count == 2
 
-    def test_run_saves_results_to_status(self, tmp_path: Path) -> None:
-        """Results from @result methods are saved to status.json."""
-        import json
-
-        from lembas.results import result
-
-        class CaseWithResults(Case):
-            value = InputParameter(type=float)
-
-            @step
-            def compute(self) -> None:
-                pass
-
-            @result("output")
-            def get_output(self) -> float:
-                return self.value * 2
-
-        case = CaseWithResults(value=5.0)
-        case.case_dir = tmp_path
-        case.run()
-
-        status_file = tmp_path / ".lembas" / "status.json"
-        assert status_file.exists()
-        status = json.loads(status_file.read_text())
-        assert status["results"] == {"output": 10.0}
-
 
 @pytest.fixture()
 def case_list() -> CaseList:

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -52,8 +52,10 @@ class MyCase(Case):
 
 
 @pytest.fixture()
-def case() -> MyCase:
-    return MyCase(my_param=3.0, required_param=1.0)
+def case(tmp_path: Path) -> MyCase:
+    c = MyCase(my_param=3.0, required_param=1.0)
+    c.case_dir = tmp_path
+    return c
 
 
 def test_case_parameter_default(case: MyCase) -> None:
@@ -107,16 +109,14 @@ def test_case_step_condition_is_met(case: MyCase) -> None:
     assert case.param_with_default == pytest.approx(5.0)
 
 
-def test_case_step_string_condition(case: MyCase, tmp_path: Path) -> None:
+def test_case_step_string_condition(case: MyCase) -> None:
     """The step with a simple string condition is run."""
-    case.case_dir = tmp_path
     case.run()
     assert case.step_has_been_triggered_by_string
 
 
-def test_case_step_string_condition_not(case: MyCase, tmp_path: Path) -> None:
+def test_case_step_string_condition_not(case: MyCase) -> None:
     """The step with a string "not" condition is run."""
-    case.case_dir = tmp_path
     case.run()
     assert case.step_has_been_triggered_by_string_not
 
@@ -197,9 +197,8 @@ def test_in_case_dir_changes_and_restores_cwd(case: MyCase, tmp_path: Path) -> N
 class TestCaseRunBehavior:
     """Tests for case run behavior: skipping completed cases/steps and force parameter."""
 
-    def test_run_skips_completed_case(self, case: MyCase, tmp_path: Path) -> None:
+    def test_run_skips_completed_case(self, case: MyCase) -> None:
         """Running a completed case a second time skips execution."""
-        case.case_dir = tmp_path
         case.run()
         assert case.first_step_has_been_run
 
@@ -275,8 +274,7 @@ class TestCaseList:
         case_list.add(case)
         assert case in case_list
 
-    def test_run_all_cases(self, case_list: CaseList, case: MyCase, tmp_path: Path) -> None:
-        case.case_dir = tmp_path
+    def test_run_all_cases(self, case_list: CaseList, case: MyCase) -> None:
         case_list.add(case)
         assert not case.second_step_has_been_run
         case_list.run_all()


### PR DESCRIPTION
## Summary

Enable incremental case execution by skipping already-completed work:

- **Skip completed cases**: `case.run()` checks if all steps have completed and returns early
- **Skip completed steps**: Individual steps that have run are skipped, allowing partial reruns
- **Force reruns**: `case.run(force=True)` bypasses skip logic and re-executes everything
- **Test isolation**: `case` fixture now uses `tmp_path` for automatic isolation

## Test plan

- [x] `test_run_skips_completed_case` — verifies completed cases are skipped on second run
- [x] `test_run_force_reruns_completed_case` — verifies `force=True` re-runs everything
- [x] All 127 tests pass
- [x] Typecheck and lint pass