### PR TITLE
chore: Add renovate regex manager for pixi version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,20 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "customManagers:githubActionsVersions"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "prefix-dev/pixi",
+      "description": "Upgrade pixi version in GitHub workflows",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "pixi-version:\\s*(?<currentValue>v[\\d.]+)"
+      ]
+    }
+  ],
   "pre-commit": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary

Add a custom regex manager to renovate config so it can automatically update `pixi-version` in GitHub workflow files.

This tracks releases from `prefix-dev/pixi` and matches the pattern `pixi-version: vX.Y.Z` in workflow YAML files.

## Test plan

- [x] Renovate should create PRs when new pixi versions are released